### PR TITLE
Suggestion: Do not brand Maui.Graphics as a Microsoft-backed, direct competition to everything graphics-related within the ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Microsoft.Maui.Graphics is a cross-platform graphics library for iOS, Android, W
 
 # Motivation
 
-Within the dotnet ecosystem there are multiple graphics libraries available depending on your target platforms; however, if you are doing cross-platform development there is not a unified graphics abstraction.  Some legacy API's (System.Drawing, I'm looking at you) only have limited support/usefulness on non-Windows platforms.  SkiaSharp runs almost everywhere these days, but for many use cases the native graphics abstractions are needed.
+[.NET MAUI](https://github.com/dotnet/maui) needs a multi-platform graphics abstraction that is backed by native API-s on all platforms.
 
 # Goals
 * No dependencies on System.Drawing


### PR DESCRIPTION
#47 makes 2 statements:

1. "premise of the library is based upon a fallacy" - I personally don't believe it's accurate. An efficient UI library needs native-backed graphics.
2. "and harms existing projects" - this is 100% true. This https://github.com/dotnet/Microsoft.Maui.Graphics/issues/47#issuecomment-801068705 explains the problem very well.

This suggestion tries to help with the second point. I believe the community raises very valid concerns which need to be addressed.