### PR TITLE
Remove double cast for alpha value from the FromUint method

### DIFF
--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Maui.Graphics
 
 		public static Color FromUint(uint argb)
 		{
-			return FromRgba((byte)((argb & 0x00ff0000) >> 0x10), (byte)((argb & 0x0000ff00) >> 0x8), (byte)(argb & 0x000000ff), (double)(byte)((argb & 0xff000000) >> 0x18));
+			return FromRgba((byte)((argb & 0x00ff0000) >> 0x10), (byte)((argb & 0x0000ff00) >> 0x8), (byte)(argb & 0x000000ff), (byte)((argb & 0xff000000) >> 0x18));
 		}
 
 		public static Color FromRgb(byte red, byte green, byte blue)

--- a/tests/Microsoft.Maui.Graphics.Tests/ColorUnitTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/ColorUnitTests.cs
@@ -294,5 +294,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Equal(Colors.Wheat, Color.FromRgb(245, 222, 179));
 			Assert.Equal(Colors.White, Color.FromRgb(255, 255, 255));
 		}
+
+        [Fact]
+        public void TestFromUint()
+        {
+            var expectedColor = new Color(1, 0.65f, 0, 1);
+
+            // Convert the expected color to a uint (argb)
+            var blue = (int)(expectedColor.Blue * 255);
+            var red = (int)(expectedColor.Red * 255);
+            var green = (int)(expectedColor.Green * 255);
+            var alpha = (int)(expectedColor.Alpha * 255);
+
+            uint argb = (uint)(blue | (green << 8) | (red << 16) | (alpha << 24));
+
+            // Create a new color from the uint
+            var fromUint = Color.FromUint(argb);
+
+            // Verify the components
+            Assert.Equal(expectedColor.Alpha, fromUint.Alpha, 2);
+            Assert.Equal(expectedColor.Red, fromUint.Red, 2);
+            Assert.Equal(expectedColor.Green, fromUint.Green, 2);
+            Assert.Equal(expectedColor.Blue, fromUint.Blue, 2);
+        }
 	}
 }


### PR DESCRIPTION
The FromUint implementation has an extra cast to a `double` for the alpha value which corrupts the resulting Color.

Adds a fix for the issue and an automated test.