### PR TITLE
Add Xmlns attributes for XAML designer

### DIFF
--- a/src/Microsoft.Maui.Graphics/AssemblyInfo.cs
+++ b/src/Microsoft.Maui.Graphics/AssemblyInfo.cs
@@ -1,9 +1,5 @@
 using Microsoft.Maui.Graphics;
 
-[assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "Microsoft.Maui.Graphics")]
-[assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms", "xf")]
-[assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms/design", "d")]
-
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.Maui.Graphics")]
 [assembly: XmlnsPrefix("http://schemas.microsoft.com/dotnet/2021/maui", "maui")]
 [assembly: XmlnsPrefix("http://schemas.microsoft.com/dotnet/2021/maui/design", "d")]

--- a/src/Microsoft.Maui.Graphics/AssemblyInfo.cs
+++ b/src/Microsoft.Maui.Graphics/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Microsoft.Maui.Graphics;
+
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2014/forms", "Microsoft.Maui.Graphics")]
+[assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms", "xf")]
+[assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms/design", "d")]
+
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Microsoft.Maui.Graphics")]
+[assembly: XmlnsPrefix("http://schemas.microsoft.com/dotnet/2021/maui", "maui")]
+[assembly: XmlnsPrefix("http://schemas.microsoft.com/dotnet/2021/maui/design", "d")]

--- a/src/Microsoft.Maui.Graphics/XmlnsDefinitionAttribute.cs
+++ b/src/Microsoft.Maui.Graphics/XmlnsDefinitionAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Maui.Graphics
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	[DebuggerDisplay("{XmlNamespace}, {ClrNamespace}")]
+	internal sealed class XmlnsDefinitionAttribute : Attribute
+	{
+		public string XmlNamespace { get; }
+		public string ClrNamespace { get; }
+
+		public XmlnsDefinitionAttribute(string xmlNamespace, string clrNamespace)
+		{
+			ClrNamespace = clrNamespace ?? throw new ArgumentNullException(nameof(xmlNamespace));
+			XmlNamespace = xmlNamespace ?? throw new ArgumentNullException(nameof(clrNamespace));
+		}
+	}
+}

--- a/src/Microsoft.Maui.Graphics/XmlnsPrefixAttribute.cs
+++ b/src/Microsoft.Maui.Graphics/XmlnsPrefixAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Microsoft.Maui.Graphics
+{
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class XmlnsPrefixAttribute : Attribute
+	{
+		public XmlnsPrefixAttribute(string xmlNamespace, string prefix)
+		{
+			XmlNamespace = xmlNamespace ?? throw new ArgumentNullException(nameof(xmlNamespace));
+			Prefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
+		}
+
+		public string XmlNamespace { get; }
+		public string Prefix { get; }
+	}
+}


### PR DESCRIPTION
The Visual Studio XAML designers require some attributes for XML namespaces.