### PR TITLE
Added more GradientPaints constructors

### DIFF
--- a/src/Microsoft.Maui.Graphics/LinearGradientPaint.cs
+++ b/src/Microsoft.Maui.Graphics/LinearGradientPaint.cs
@@ -8,8 +8,25 @@
 			EndPoint = new Point(1, 1);
 		}
 
+		public LinearGradientPaint(GradientPaint gradientPaint) : base(gradientPaint)
+		{
+		
+		}
+
+		public LinearGradientPaint(GradientStop[] gradientStops)
+		{
+			GradientStops = gradientStops;
+		}
+
 		public LinearGradientPaint(Point startPoint, Point endPoint)
 		{
+			StartPoint = startPoint;
+			EndPoint = endPoint;
+		}
+
+		public LinearGradientPaint(GradientStop[] gradientStops, Point startPoint, Point endPoint)
+		{
+			GradientStops = gradientStops;
 			StartPoint = startPoint;
 			EndPoint = endPoint;
 		}

--- a/src/Microsoft.Maui.Graphics/RadialGradientPaint.cs
+++ b/src/Microsoft.Maui.Graphics/RadialGradientPaint.cs
@@ -8,8 +8,25 @@
 			Radius = 0.5;
 		}
 
+		public RadialGradientPaint(GradientPaint gradientPaint) : base(gradientPaint)
+		{
+
+		}
+
+		public RadialGradientPaint(GradientStop[] gradientStops)
+		{
+			GradientStops = gradientStops;
+		}
+
 		public RadialGradientPaint(Point center, double radius)
 		{
+			Center = center;
+			Radius = radius;
+		}
+
+		public RadialGradientPaint(GradientStop[] gradientStops, Point center, double radius)
+		{
+			GradientStops = gradientStops;
 			Center = center;
 			Radius = radius;
 		}

--- a/src/Microsoft.Maui.Graphics/SolidPaint.cs
+++ b/src/Microsoft.Maui.Graphics/SolidPaint.cs
@@ -6,6 +6,11 @@
 		{
 		}
 
+		public SolidPaint(Color color)
+		{
+			Color = color;
+		}
+
 		public Color Color { get; set; }
 
 		public override bool IsTransparent


### PR DESCRIPTION
Add more constructors to LinearGradientPaint and RadialGradientPaint. In this way, the initialization of these Paints can be the same as what can be done with brushes in Xamarin.Forms.