### PR TITLE
Obsolete ambiguous ToHex and FromHex

### DIFF
--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics
 		public Color()
 		{
 			// Default Black - param-less ctor need for some XAML/TypeConverter things
-			Red = Green = Blue = 0;	
+			Red = Green = Blue = 0;
 		}
 
 		public Color(float gray)
@@ -63,6 +63,7 @@ namespace Microsoft.Maui.Graphics
 			return base.Equals(obj);
 		}
 
+		[Obsolete("Use ToArgbHex instead.")]
 		public string ToHex(bool includeAlpha = false)
 		{
 			if (includeAlpha || Alpha < 1)
@@ -71,6 +72,23 @@ namespace Microsoft.Maui.Graphics
 			return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue);
 		}
 
+		public string ToArgbHex(bool includeAlpha = false)
+		{
+			if (includeAlpha || Alpha < 1)
+				return "#" + ToHex(Alpha) + ToHex(Red) + ToHex(Green) + ToHex(Blue);
+
+			return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue);
+		}
+
+		public string ToRgbaHex(bool includeAlpha = false)
+		{
+			if (includeAlpha || Alpha < 1)
+				return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue) + ToHex(Alpha);
+
+			return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue);
+		}
+
+		[Obsolete("Use FromArgb instead.")]
 		public static Color FromHex(string colorAsHex) => FromArgb(colorAsHex);
 
 		public Paint AsPaint()

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -64,11 +64,16 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		[Obsolete("Use ToArgbHex instead.")]
-		public string ToHex(bool includeAlpha = false)
+		public string ToHex(bool includeAlpha)
 		{
 			if (includeAlpha || Alpha < 1)
 				return "#" + ToHex(Alpha) + ToHex(Red) + ToHex(Green) + ToHex(Blue);
 
+			return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue);
+		}
+
+		public string ToHex()
+		{
 			return "#" + ToHex(Red) + ToHex(Green) + ToHex(Blue);
 		}
 

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		[Obsolete("Use FromArgb instead.")]
-		public static Color FromHex(string colorAsHex) => FromArgb(colorAsHex);
+		public static Color FromHex(string colorAsArgbHex) => FromArgb(colorAsArgbHex);
 
 		public Paint AsPaint()
 		{


### PR DESCRIPTION
`ToHex(bool includeAlpha = false)` outputs `#AARRBBGG` which is slightly ambiguous.  Deprecated that method, made the parameter non-optional, and directed to use the new `ToArgbHex()` method instead, and also added a `ToRgbaHex()` method variation.  Finally, added `ToHex()` with no bool parameter which outputs a hex string with no alpha at all.

Similarly, obsoleted the `FromHex` which expects `#AARRBBGG`  as the input, and renamed the parameter name to be more descriptive of the expectation.  `FromHex` just calls `FromArgb(string)` already, so that can be used directly, as well as its already existing `FromRgba(string)` counterpart.

