### PR TITLE
Ensure EncoderParameters is disposed

### DIFF
--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDIImage.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDIImage.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Maui.Graphics.GDI
 				{
 					var jgpEncoder = GetEncoder(Drawing.Imaging.ImageFormat.Jpeg);
 					var myEncoder = Encoder.Quality;
-					var myEncoderParameters = new EncoderParameters(1);
-					var myEncoderParameter = new EncoderParameter(myEncoder, (long) (quality * 100));
-					myEncoderParameters.Param[0] = myEncoderParameter;
-
-					_bitmap.Save(stream, jgpEncoder, myEncoderParameters);
+					using (var myEncoderParameters = new EncoderParameters(1))
+					{
+						myEncoderParameters.Param[0] = new EncoderParameter(myEncoder, (long)(quality * 100));
+						_bitmap.Save(stream, jgpEncoder, myEncoderParameters);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
`EncoderParameters` was not being disposed which leads to leaking of unmanaged memory. 

As a side note. Contributing this fix was not a great developmental experience. I think it might be wise to add documentation to the readme explaining what VS features are required plus SDK versions in order to successfully build the project. 