### PR TITLE
[Skia] Fix DrawString with Vertically center align

### DIFF
--- a/src/Microsoft.Maui.Graphics.Skia/SkiaTextLayout.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/SkiaTextLayout.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Maui.Graphics.Skia
 
 			// Figure out the center index of the list, and the center point to start drawing from.
 			var startIndex = (lines.Count / 2);
-			if (linesToDraw % 2 == 0)
+			if (linesToDraw % 2 != 0)
 				y -= _lineHeight / 2;
 
 			// Figure out which index to draw first (of the range) and the point of the first line.


### PR DESCRIPTION
This PR fix https://github.com/dotnet/Microsoft.Maui.Graphics/issues/106

![image](https://user-images.githubusercontent.com/1029155/123203345-2b15fc00-d4f1-11eb-8dca-f6053ea16a93.png)
![image](https://user-images.githubusercontent.com/1029155/123203358-2f421980-d4f1-11eb-9029-1d1abd02441f.png)

