### PR TITLE
Fix ScalingCanvas scaling issue

### DIFF
--- a/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
@@ -213,12 +213,11 @@ namespace Microsoft.Maui.Graphics
 		{
 			_scaleX *= Math.Abs(sx);
 			_scaleY *= Math.Abs(sy);
-			_canvas.Scale(sx, sy);
 		}
 
 		public void Translate(float tx, float ty)
 		{
-			_canvas.Translate(tx, ty);
+			_canvas.Translate(tx * _scaleX, ty * _scaleY);
 		}
 
 		public void ConcatenateTransform(AffineTransform transform)


### PR DESCRIPTION
This PR fix https://github.com/dotnet/Microsoft.Maui.Graphics/issues/109

`Scale` method in ScalingCanvas, should not scale a original canvas, because ScalingCanvas will scale a path in each method.

Test code
``` c#
canvas.SaveState();

canvas.StrokeColor = Colors.Black;
canvas.DrawRectangle(new Rectangle(10, 10, 20, 20));

var normalScale = new ScalingCanvas(canvas);

var scaledCanvas = new ScalingCanvas(normalScale);
scaledCanvas.Scale(2, 2);

scaledCanvas.StrokeColor = Colors.Black;
scaledCanvas.DrawRectangle(new Rectangle(10, 10, 20, 20));

scaledCanvas.Translate(10, 10);

scaledCanvas.StrokeColor = Colors.Red;
scaledCanvas.DrawRectangle(new Rectangle(10, 10, 20, 20));

canvas.RestoreState();
```
![image](https://user-images.githubusercontent.com/1029155/123248894-65988c80-d523-11eb-89de-24ff90782d7f.png)
