### PR TITLE
Update Tizen backend

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -19,6 +19,12 @@
       "commands": [
         "vs"
       ]
+    },
+    "boots": {
+      "version": "1.0.4.624",
+      "commands": [
+        "boots"
+      ]
     }
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   DotNet.Cli.Telemetry.OptOut: true
   MauiCheck.Version: 0.6.1
   Maui.Version: --preview
+  Tizen.Version: 6.5.100-preview.5.57
 
 parameters:
   - name: BuildConfigurations
@@ -84,6 +85,10 @@ stages:
 
             - pwsh: dotnet tool restore
               displayName: install dotnet tools
+
+            - pwsh:
+                dotnet boots --url https://workload-bin.s3.ap-northeast-2.amazonaws.com/windows/Samsung.NET.Workload.Tizen.$(Tizen.Version).msi
+              displayName: install tizen
 
             - pwsh: |
                 # Update the installer installer

--- a/build/Build.Microsoft.Maui.Graphics.Mac.sln
+++ b/build/Build.Microsoft.Maui.Graphics.Mac.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31509.46
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics", "..\src\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj", "{76F3031E-341E-43CC-BD92-B23F83495DB7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Maui.Graphics", "..\src\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj", "{76F3031E-341E-43CC-BD92-B23F83495DB7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Text.Markdig", "..\src\Microsoft.Maui.Graphics.Text.Markdig\Microsoft.Maui.Graphics.Text.Markdig.csproj", "{ED36FB6D-7278-465D-9C44-D01927258BA1}"
 EndProject
@@ -16,33 +16,33 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8A2197EB-6E30-495D-9DE9-2E40032FB2E9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Skia", "..\src\Microsoft.Maui.Graphics.Skia\Microsoft.Maui.Graphics.Skia.csproj", "{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}"
-EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{5163bcb2-4d70-42da-975a-af55d6b6a0b3}*SharedItemsImports = 13
+		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{694e970d-5c18-483f-bc48-d6d86da8e78f}*SharedItemsImports = 4
+		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{95a3e5f1-26b7-4bd8-8f01-48fe7bfd79fa}*SharedItemsImports = 13
+		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{bc291304-fdc0-4e1d-a673-39f5e446b0e0}*SharedItemsImports = 5
+		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{edf26ebb-0ac3-4212-81d6-8dd08f5acc17}*SharedItemsImports = 4
+		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{f8d43f64-af09-4e06-8473-5bdc37281908}*SharedItemsImports = 4
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		AppStore|Any CPU = AppStore|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		AppStore|Any CPU = AppStore|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.AppStore|Any CPU.Build.0 = Debug|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,7 +50,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{76F3031E-341E-43CC-BD92-B23F83495DB7} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 		{ED36FB6D-7278-465D-9C44-D01927258BA1} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
-		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B07E734-6AE2-4A12-AD60-C072F3695854}

--- a/build/Build.Microsoft.Maui.Graphics.Mac.sln
+++ b/build/Build.Microsoft.Maui.Graphics.Mac.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30523.141
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31509.46
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Maui.Graphics", "..\src\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj", "{76F3031E-341E-43CC-BD92-B23F83495DB7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics", "..\src\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj", "{76F3031E-341E-43CC-BD92-B23F83495DB7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Text.Markdig", "..\src\Microsoft.Maui.Graphics.Text.Markdig\Microsoft.Maui.Graphics.Text.Markdig.csproj", "{ED36FB6D-7278-465D-9C44-D01927258BA1}"
 EndProject
@@ -16,33 +16,33 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8A2197EB-6E30-495D-9DE9-2E40032FB2E9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Skia", "..\src\Microsoft.Maui.Graphics.Skia\Microsoft.Maui.Graphics.Skia.csproj", "{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{5163bcb2-4d70-42da-975a-af55d6b6a0b3}*SharedItemsImports = 13
-		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{694e970d-5c18-483f-bc48-d6d86da8e78f}*SharedItemsImports = 4
-		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{95a3e5f1-26b7-4bd8-8f01-48fe7bfd79fa}*SharedItemsImports = 13
-		..\src\Microsoft.Maui.Graphics.SharpDX.Shared\Microsoft.Maui.Graphics.SharpDX.Shared.projitems*{bc291304-fdc0-4e1d-a673-39f5e446b0e0}*SharedItemsImports = 5
-		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{edf26ebb-0ac3-4212-81d6-8dd08f5acc17}*SharedItemsImports = 4
-		..\src\Microsoft.Maui.Graphics.CoreGraphics\Microsoft.Maui.Graphics.CoreGraphics.projitems*{f8d43f64-af09-4e06-8473-5bdc37281908}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		AppStore|Any CPU = AppStore|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		AppStore|Any CPU = AppStore|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76F3031E-341E-43CC-BD92-B23F83495DB7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{76F3031E-341E-43CC-BD92-B23F83495DB7}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED36FB6D-7278-465D-9C44-D01927258BA1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{ED36FB6D-7278-465D-9C44-D01927258BA1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,6 +50,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{76F3031E-341E-43CC-BD92-B23F83495DB7} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 		{ED36FB6D-7278-465D-9C44-D01927258BA1} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
+		{542F8AA6-2FC5-4DCC-9DB7-46D0FEA4424F} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B07E734-6AE2-4A12-AD60-C072F3695854}

--- a/build/Build.Microsoft.Maui.Graphics.Windows.sln
+++ b/build/Build.Microsoft.Maui.Graphics.Windows.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30523.141
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31509.46
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics", "..\src\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj", "{76F3031E-341E-43CC-BD92-B23F83495DB7}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Maui.Graphics.Win2D.UWP", "..\src\Microsoft.Maui.Graphics.Win2D.UWP\Microsoft.Maui.Graphics.Win2D.UWP.csproj", "{20794E60-3BFD-46F4-BC0B-87B3959AA3C7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Win2D.WinUI.Desktop", "..\src\Microsoft.Maui.Graphics.Win2D.WinUI.Desktop\Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.csproj", "{98851CCB-2A9B-4FDE-8D2A-4F6139EA5A9F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.Graphics.Skia", "..\src\Microsoft.Maui.Graphics.Skia\Microsoft.Maui.Graphics.Skia.csproj", "{6738582B-6246-486B-B90E-6C80799736B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,22 @@ Global
 		{98851CCB-2A9B-4FDE-8D2A-4F6139EA5A9F}.Release|x64.Build.0 = Release|Any CPU
 		{98851CCB-2A9B-4FDE-8D2A-4F6139EA5A9F}.Release|x86.ActiveCfg = Release|Any CPU
 		{98851CCB-2A9B-4FDE-8D2A-4F6139EA5A9F}.Release|x86.Build.0 = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|ARM.Build.0 = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|x64.Build.0 = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Debug|x86.Build.0 = Debug|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|ARM.ActiveCfg = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|ARM.Build.0 = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|x64.ActiveCfg = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|x64.Build.0 = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{6738582B-6246-486B-B90E-6C80799736B5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -100,6 +118,7 @@ Global
 		{ED36FB6D-7278-465D-9C44-D01927258BA1} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 		{20794E60-3BFD-46F4-BC0B-87B3959AA3C7} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 		{98851CCB-2A9B-4FDE-8D2A-4F6139EA5A9F} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
+		{6738582B-6246-486B-B90E-6C80799736B5} = {9E4B772B-D417-4147-B8B1-FD9E3B0B4EC5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B07E734-6AE2-4A12-AD60-C072F3695854}

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -45,6 +45,21 @@
         <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
         <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
       </group>
+      <group targetFramework="xamarin.ios10">
+        <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
+        <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
+        <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
+      </group>
+      <group targetFramework="monoandroid10.0">
+        <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
+        <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
+        <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
+      </group>
+      <group targetFramework="xamarin.mac20">
+        <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
+        <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
+        <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
+      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
@@ -71,7 +86,16 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.Skia.pdb"/>
+
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/monoandroid10.0/Microsoft.Maui.Graphics.Skia.dll" target="lib/monoandroid10.0/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/monoandroid10.0/Microsoft.Maui.Graphics.Skia.pdb" target="lib/monoandroid10.0/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.dll" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizne40/Microsoft.Maui.Graphics.Skia.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.pdb"/>
   </files>
 </package>

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -35,6 +35,16 @@
         <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
         <dependency id="SkiaSharp.Views.WinUI" version="2.88.0-preview.61"/>
       </group>
+      <group targetFramework="net6.0-tizen">
+        <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
+        <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
+        <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
+      </group>
+      <group targetFramework="tizen40">
+        <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
+        <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
+        <dependency id="SkiaSharp.Views" version="2.88.0-preview.61"/>
+      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0-preview.61"/>
@@ -59,5 +69,9 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.dll" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizne40/Microsoft.Maui.Graphics.Skia.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.pdb"/>
   </files>
 </package>

--- a/build/Microsoft.Maui.Graphics.nuspec
+++ b/build/Microsoft.Maui.Graphics.nuspec
@@ -19,6 +19,8 @@
       <group targetFramework="net6.0-ios13.6" />
       <group targetFramework="net6.0-maccatalyst13.5" />
       <group targetFramework="net6.0-windows10.0.18362" />
+      <group targetFramework="net6.0-tizen" />
+      <group targetFramework="tizen40" />
       <group targetFramework=".NETStandard2.0" />
       <group targetFramework=".NETStandard2.1" />
     </dependencies>
@@ -37,5 +39,9 @@
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.dll" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-tizen/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.dll" target="lib/tizen40/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.pdb"/>
   </files>
 </package>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="SkiaSharp" Version="2.88.0-preview.61" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.Contains('-android')) or $(TargetFramework.Contains('-ios')) or $(TargetFramework.Contains('-maccatalyst'))">
+  <ItemGroup Condition="$(TargetFramework.Contains('-android')) or $(TargetFramework.Contains('-ios')) or $(TargetFramework.Contains('-maccatalyst')) or $(TargetFramework.Contains('-tizen'))">
     <PackageReference Include="SkiaSharp.Views" Version="2.88.0-preview.61" />
   </ItemGroup>
 

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-windows10.0.18362;net6.0-tizen</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
   </PropertyGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
@@ -1,27 +1,23 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
+
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;tizen40</TargetFrameworks>
-        <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
-        <Version>2.0.0</Version>
-    </PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;Xamarin.iOS10;MonoAndroid10.0;Xamarin.Mac20;tizen40</TargetFrameworks>
+    <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="Views\" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="SkiaSharp" Version="2.80.3" />
-        <PackageReference Include="SkiaSharp.Views" Version="2.80.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Microsoft.Maui.Graphics\Microsoft.Maui.Graphics.csproj" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20' Or '$(TargetFramework)' == 'netstandard2.1'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20' Or '$(TargetFramework)' == 'netstandard2.1'">
-        <Reference Include="netstandard" />
-    </ItemGroup>
+  <Import Project="..\targets\MultiTargeting.targets" />
 
-    <Import Project="..\targets\MultiTargeting.targets" />
 </Project>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;tizen40</TargetFrameworks>
         <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
         <Version>2.0.0</Version>
     </PropertyGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Mac.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Mac.cs
@@ -1,6 +1,6 @@
 
 using System;
-using Microsoft.Maui.Graphics.CoreGraphics;
+using Microsoft.Maui.Graphics.Native;
 using Microsoft.Maui.Graphics.Skia;
 using SkiaSharp.Views.Mac;
 

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-windows10.0.18362;net6.0-tizen</TargetFrameworks>
       <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
       <PublishRepositoryUrl>true</PublishRepositoryUrl>
       <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;Xamarin.iOS10;MonoAndroid10.0;Xamarin.Mac20;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;Xamarin.iOS10;MonoAndroid10.0;Xamarin.Mac20;tizen40</TargetFrameworks>
       <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
       <PublishRepositoryUrl>true</PublishRepositoryUrl>
       <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->


### PR DESCRIPTION
This fix supports `net6.0-tizen`.  
> Make sure that you have to install the Tizen workload for .NET 6.0 (preview) in advance.
> See [here](https://github.com/Samsung/Tizen.NET#installing-tizen-workload-for-net-60-preview).

And, this PR also support `tizen40` for legacy tizen projects.

<img src="https://user-images.githubusercontent.com/1029134/125423211-492d7a22-bd89-489b-83b5-cf3c8558369d.gif" width=320/>

Thanks to @mattleibow and @Redth for the quick support. ❤️ 