### PR TITLE
Update Skia package URLs

### DIFF
--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -10,8 +10,8 @@
     <description>SkiaSharp implementation for Microsoft.Maui.Graphics.Skia</description>
     <summary>This allows you to use SkiaSharp as a Microsoft.Maui.Graphics.Skia target.</summary>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <projectUrl>https://github.com/dotnet/Microsoft.Maui.Graphics.Skia</projectUrl>
-    <repository type="git" url="https://github.com/dotnet/Microsoft.Maui.Graphics.Skia"/>
+    <projectUrl>https://github.com/dotnet/Microsoft.Maui.Graphics</projectUrl>
+    <repository type="git" url="https://github.com/dotnet/Microsoft.Maui.Graphics"/>
     <license type="expression">MIT</license>
     <language>C#</language>
     <dependencies>


### PR DESCRIPTION
Fixes project and repository URLs which currently 404 on the [Microsoft.Maui.Graphics.Skia NuGet page](https://www.nuget.org/packages/Microsoft.Maui.Graphics.Skia). Fixes #137