### PR TITLE
Remove default check on converters

### DIFF
--- a/src/Microsoft.Maui.Graphics/Converters/PointFTypeConverter.cs
+++ b/src/Microsoft.Maui.Graphics/Converters/PointFTypeConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Converters
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (PointF.TryParse(value?.ToString(), out var p) && p != default)
+			if (PointF.TryParse(value?.ToString(), out var p))
 				return p;
 
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(PointF)));

--- a/src/Microsoft.Maui.Graphics/Converters/PointTypeConverter.cs
+++ b/src/Microsoft.Maui.Graphics/Converters/PointTypeConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Converters
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (Point.TryParse(value?.ToString(), out var p) && p != default)
+			if (Point.TryParse(value?.ToString(), out var p))
 				return p;
 
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(Point)));

--- a/src/Microsoft.Maui.Graphics/Converters/RectangleFTypeConverter.cs
+++ b/src/Microsoft.Maui.Graphics/Converters/RectangleFTypeConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Converters
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (RectangleF.TryParse(value?.ToString(), out var r) && r != default)
+			if (RectangleF.TryParse(value?.ToString(), out var r))
 				return r;
 
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(RectangleF)));

--- a/src/Microsoft.Maui.Graphics/Converters/RectangleTypeConverter.cs
+++ b/src/Microsoft.Maui.Graphics/Converters/RectangleTypeConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Converters
 
 		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
-			if (Rectangle.TryParse(value?.ToString(), out var r) && r != default)
+			if (Rectangle.TryParse(value?.ToString(), out var r))
 				return r;
 
 			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(Rectangle)));

--- a/tests/Microsoft.Maui.Graphics.Tests/ColorTypeConverterTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/ColorTypeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Maui.Graphics.Converters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,9 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(ColorConvertData))]
 		public void ConvertsFromString(string from, Color expected)
 		{
-			Assert.Equal(expected, Color.Parse(from));
+			bool ok = from.TryConvertFrom<ColorTypeConverter, Color>(out var c);
+			Assert.True(ok);
+			Assert.Equal(expected, c);
 		}
 
 		// Supported inputs

--- a/tests/Microsoft.Maui.Graphics.Tests/PointTypeConverterTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/PointTypeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Maui.Graphics.Converters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(PointConvertData))]
 		public void ConvertsPointFromString(string from, bool expectedSuccess, Point expectedResult)
 		{
-			var ok = Point.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<PointTypeConverter, Point>(out var p);
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(PointFConvertData))]
 		public void ConvertsPointFFromString(string from, bool expectedSuccess, PointF expectedResult)
 		{
-			var ok = PointF.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<PointFTypeConverter, PointF>(out var p);
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)

--- a/tests/Microsoft.Maui.Graphics.Tests/RectangleTypeConverterTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/RectangleTypeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Maui.Graphics.Converters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(RectangleConvertData))]
 		public void ConvertsRectangleFromString(string from, bool expectedSuccess, Rectangle expectedResult)
 		{
-			var ok = Rectangle.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<RectangleTypeConverter, Rectangle>(out var p);
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(RectangleFConvertData))]
 		public void ConvertsRectangleFFromString(string from, bool expectedSuccess, RectangleF expectedResult)
 		{
-			var ok = RectangleF.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<RectangleFTypeConverter, RectangleF>(out var p);
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)

--- a/tests/Microsoft.Maui.Graphics.Tests/SizeTypeConverterTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/SizeTypeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Maui.Graphics.Converters;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(SizeConvertData))]
 		public void ConvertsSizeFromString(string from, bool expectedSuccess, Size expectedResult)
 		{
-			var ok = Size.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<SizeTypeConverter, Size>(out var p);
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)
@@ -25,7 +26,7 @@ namespace Microsoft.Maui.Graphics.Tests
 		[MemberData(nameof(SizeFConvertData))]
 		public void ConvertsSizeFFromString(string from, bool expectedSuccess, SizeF expectedResult)
 		{
-			var ok = SizeF.TryParse(from, out var p);
+			var ok = from.TryConvertFrom<SizeFTypeConverter, SizeF>(out var p); 
 			Assert.Equal(expectedSuccess, ok);
 
 			if (expectedSuccess)

--- a/tests/Microsoft.Maui.Graphics.Tests/TypeConverterExtensions.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/TypeConverterExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Maui.Graphics.Tests
+{
+	public static class TypeConverterExtensions
+	{
+		public static bool TryConvertFrom<TConverterType, T>(this string input, out T result)
+			where TConverterType : TypeConverter, new()
+		{
+			var converter = new TConverterType();
+
+			try
+			{
+				result = (T)converter.ConvertFrom(input);
+				return true;
+			}
+			catch { }
+
+			result = default;
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
The type converters are returning false if the string parses to `default`

This means values like "0,0" for point will return false because the default value for point is "0,0" 

This also modifies the unit tests to test against the Type Converters instead of the `TryParse` methods