### PR TITLE
Fix NuGet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft.Maui.Graphics
 
-![NuGet](https://badgen.net/nuget/v/Microsoft.Maui.Graphics)
+[![NuGet](https://badgen.net/nuget/v/Microsoft.Maui.Graphics)](https://www.nuget.org/packages/Microsoft.Maui.Graphics/)
 
 Microsoft.Maui.Graphics is a cross-platform graphics library for iOS, Android, Windows, macOS, Tizen and Linux completely in C#.  With this library you can use a common API to target multiple abstractions allowing you to share your drawing code between platforms, or mix and match graphics implentations within a singular application.
 


### PR DESCRIPTION
Clicking on NuGet image in readme now opens NuGet page on nuget.org.