### PR TITLE
[Skia.WPF] improve OnRenderSizeChanged()

### DIFF
--- a/src/Microsoft.Maui.Graphics.Skia.WPF/WDSkiaGraphicsView.cs
+++ b/src/Microsoft.Maui.Graphics.Skia.WPF/WDSkiaGraphicsView.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Maui.Graphics.Skia
 		protected override void OnRenderSizeChanged(
 			SizeChangedInfo sizeInfo)
 		{
+			base.OnRenderSizeChanged(sizeInfo);
 			_dirtyRect.Width = (float) sizeInfo.NewSize.Width;
 			_dirtyRect.Height = (float) sizeInfo.NewSize.Height;
 			_renderer?.SizeChanged((int) sizeInfo.NewSize.Width, (int) sizeInfo.NewSize.Height);


### PR DESCRIPTION
This PR fixes a bug that causes the painted area not to match the window when resizing. If the `OnRenderSizeChanged()` override does not call its base implementation the `SizeChanged` event isn't raised and the dirty rectangle may be incorrectly sized when `OnPaintSurface()` is called. Note [mono / SKElement.cs#L88-L93](https://github.com/mono/SkiaSharp/blob/2ad29861d5a40d3bf78c28ab0a9cb02a8f0fe437/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs#L88-L93)

`WDSkiaGraphicsView` inherits `SKElement` which inherits `FrameworkElement`

According to [`FrameworkElement.OnRenderSizeChanged()` documentation](https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.onrendersizechanged?view=net-5.0): 
> You may still override OnRenderSizeChanged() in derived classes (it is protected but not sealed). Always call the base implementation to preserve the [layout] behavior mentioned above, unless you have very specific reasons for disabling default WPF framework-level rendering behavior. Failing to raise the SizeChanged event will cause non-standard layout behavior if using the standard WPF framework-level layout system implementation.

I realize this project is experimental/preview, so clarification on whether contributions are welcome at this time and if PRs must be accompanied by linked issues would be great! (#88)

## Demonstrating the Issue

```xaml
<skia:WDSkiaGraphicsView x:Name="GraphicsView" />
```

```cs
public partial class SandboxWindow : Window
{
    public SandboxWindow()
    {
        InitializeComponent();
        GraphicsView.Drawable = new BigX();
    }

    private class BigX : IDrawable
    {
        public void Draw(ICanvas canvas, RectangleF dirtyRect)
        {
            canvas.FillColor = Microsoft.Maui.Graphics.Colors.Navy;
            canvas.FillRectangle(dirtyRect);

            canvas.StrokeColor = Microsoft.Maui.Graphics.Colors.Yellow;
            canvas.DrawRectangle(dirtyRect);
            canvas.DrawLine(0, 0, dirtyRect.Width, dirtyRect.Height);
            canvas.DrawLine(dirtyRect.Width, 0, 0, dirtyRect.Height);
        }
    }
}
```

## Before the Fix
Notice the white border around the filled area when resizing quickly
![maui-whitespace-broken](https://user-images.githubusercontent.com/4165489/132956519-37dd3947-0a78-43b4-854a-13f3d3331435.gif)

## After the Fix
Filled area exactly matches the window size
![maui-whitespace-fixed](https://user-images.githubusercontent.com/4165489/132956524-7c79c93e-e636-4a3b-adc7-120754e2e457.gif)