### PR TITLE
[WinForms.GDI] improve support for gradient fills

### DIFF
--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
@@ -497,24 +497,38 @@ namespace Microsoft.Maui.Graphics.GDI
 				return;
 			}
 
-			/*
 			if (paint is LinearGradientPaint linearGradientPaint)
 			{
-				point1.X = x1;
-				point1.Y = y1;
-				point2.X = x2;
-				point2.Y = y2;
-				currentState.SetLinearGradient(paint, point1, point2);
+				float x1 = (float)(linearGradientPaint.StartPoint.X * rectangle.Width) + rectangle.X;
+				float y1 = (float)(linearGradientPaint.StartPoint.Y * rectangle.Height) + rectangle.Y;
+
+				float x2 = (float)(linearGradientPaint.EndPoint.X * rectangle.Width) + rectangle.X;
+				float y2 = (float)(linearGradientPaint.EndPoint.Y * rectangle.Height) + rectangle.Y;
+
+				CurrentState.FillBrushLinear = new LinearGradientBrush(
+				   new Drawing.PointF(x1, y1),
+				   new Drawing.PointF(x2, y2),
+				   linearGradientPaint.StartColor.AsColor(),
+				   linearGradientPaint.EndColor.AsColor());
+				return;
 			}
-			else if(paint is RadialGradientPaint radialGradientPaint)
+
+			if (paint is RadialGradientPaint radialGradientPaint)
 			{
-				point1.X = x1;
-				point1.Y = y1;
-				point2.X = x2;
-				point2.Y = y2;
-				currentState.SetRadialGradient(paint, point1, point2);
+				float x1 = (float)(radialGradientPaint.Center.X * rectangle.Width) + rectangle.X;
+				float y1 = (float)(radialGradientPaint.Center.Y * rectangle.Height) + rectangle.Y;
+				float w = rectangle.Width;
+				float h = rectangle.Height;
+
+				GraphicsPath path = new GraphicsPath();
+				path.AddEllipse(x1, y1, w, h);
+
+				CurrentState.FillBrushPath = new PathGradientBrush(path)
+				{
+					CenterColor = radialGradientPaint.StartColor.AsColor(),
+					SurroundColors = new Drawing.Color[] { radialGradientPaint.EndColor.AsColor() },
+				};
 			}
-			*/
 		}
 
 		public override void SetToSystemFont()

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
@@ -505,11 +505,13 @@ namespace Microsoft.Maui.Graphics.GDI
 				float x2 = (float)(linearGradientPaint.EndPoint.X * rectangle.Width) + rectangle.X;
 				float y2 = (float)(linearGradientPaint.EndPoint.Y * rectangle.Height) + rectangle.Y;
 
-				CurrentState.FillBrushLinear = new LinearGradientBrush(
-				   new Drawing.PointF(x1, y1),
-				   new Drawing.PointF(x2, y2),
-				   linearGradientPaint.StartColor.AsColor(),
-				   linearGradientPaint.EndColor.AsColor());
+				Drawing.PointF point1 = new Drawing.PointF(x1, y1);
+				Drawing.PointF point2 = new Drawing.PointF(x2, y2);
+				Drawing.Color color1 = linearGradientPaint.StartColor.AsColor();
+				Drawing.Color color2 = linearGradientPaint.EndColor.AsColor();
+
+				CurrentState.SetFillLinear(point1, point2, color1, color2);
+
 				return;
 			}
 
@@ -522,12 +524,10 @@ namespace Microsoft.Maui.Graphics.GDI
 
 				GraphicsPath path = new GraphicsPath();
 				path.AddEllipse(x1, y1, w, h);
+				Drawing.Color color1 = radialGradientPaint.StartColor.AsColor();
+				Drawing.Color color2 = radialGradientPaint.EndColor.AsColor();
 
-				CurrentState.FillBrushPath = new PathGradientBrush(path)
-				{
-					CenterColor = radialGradientPaint.StartColor.AsColor(),
-					SurroundColors = new Drawing.Color[] { radialGradientPaint.EndColor.AsColor() },
-				};
+				CurrentState.SetFillRadial(path, color1, color2);
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
@@ -515,10 +515,10 @@ namespace Microsoft.Maui.Graphics.GDI
 
 			if (paint is RadialGradientPaint radialGradientPaint)
 			{
-				float x1 = (float)(radialGradientPaint.Center.X * rectangle.Width) + rectangle.X;
-				float y1 = (float)(radialGradientPaint.Center.Y * rectangle.Height) + rectangle.Y;
-				float w = rectangle.Width;
-				float h = rectangle.Height;
+				float x1 = (float)((radialGradientPaint.Center.X - radialGradientPaint.Radius) * rectangle.Width) + rectangle.X;
+				float y1 = (float)((radialGradientPaint.Center.Y - radialGradientPaint.Radius) * rectangle.Height) + rectangle.Y;
+				float w = rectangle.Width * (float)radialGradientPaint.Radius * 2;
+				float h = rectangle.Height * (float)radialGradientPaint.Radius * 2;
 
 				GraphicsPath path = new GraphicsPath();
 				path.AddEllipse(x1, y1, w, h);

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
@@ -131,22 +131,44 @@ namespace Microsoft.Maui.Graphics.GDI
 
 		public Drawing.Color StrokeColor { get; set; }
 
-		public Drawing.Color FillColor { get; set; }
+		private Drawing.Color _fillColor;
+		public Drawing.Color FillColor
+		{
+			get => _fillColor;
+			set
+			{
+				_fillColor = value;
+				FillBrushLinear = null;
+				FillBrushPath = null;
+			}
+		}
+
+		public SolidBrush FillBrushSolid { get; set; }
+		public LinearGradientBrush FillBrushLinear { get; set; }
+		public PathGradientBrush FillBrushPath { get; set; }
 
 		public Brush FillBrush
 		{
 			get
 			{
-				if (_fillBrush == null)
+				if (FillBrushPath != null)
 				{
-					_fillBrush = new SolidBrush(FillColor);
-				}
-				else
-				{
-					_fillBrush.Color = FillColor;
+					return FillBrushPath;
 				}
 
-				return _fillBrush;
+				if (FillBrushLinear != null)
+				{
+					return FillBrushLinear;
+				}
+
+				if (FillBrushSolid != null)
+				{
+					FillBrushSolid.Color = FillColor;
+					return FillBrushSolid;
+				}
+
+				FillBrushSolid = new SolidBrush(Drawing.Color.White);
+				return FillBrushSolid;
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Maui.Graphics.GDI
 		private Pen _strokePen;
 		private GraphicsState _state;
 
-		private SolidBrush _fillBrush;
+		private SolidBrush _fillBrushSolid;
+		private LinearGradientBrush _fillBrushLinear;
+		private PathGradientBrush _fillBrushRadial;
+		private Brush _activeBrush;
 
 		private SolidBrush _textBrush;
 		private Font _font;
@@ -138,41 +141,48 @@ namespace Microsoft.Maui.Graphics.GDI
 			set
 			{
 				_fillColor = value;
-
-				FillBrushLinear?.Dispose();
-				FillBrushLinear = null;
-
-				FillBrushPath?.Dispose();
-				FillBrushPath = null;
+				SetFillSolid(value);
 			}
 		}
 
-		public SolidBrush FillBrushSolid { get; set; }
-		public LinearGradientBrush FillBrushLinear { get; set; }
-		public PathGradientBrush FillBrushPath { get; set; }
+		public void SetFillSolid(Drawing.Color color)
+		{
+			if (_fillBrushSolid is null)
+				_fillBrushSolid = new SolidBrush(Drawing.Color.White);
+
+			_fillBrushSolid.Color = color;
+
+			_activeBrush = _fillBrushSolid;
+		}
+
+		public void SetFillLinear(Drawing.PointF point1, Drawing.PointF point2, Drawing.Color color1, Drawing.Color color2)
+		{
+			_fillBrushLinear?.Dispose();
+			_fillBrushLinear = new LinearGradientBrush(point1, point2, color1, color2);
+
+			_activeBrush = _fillBrushLinear;
+		}
+
+		public void SetFillRadial(GraphicsPath path, Drawing.Color center, Drawing.Color surround)
+		{
+			_fillBrushRadial?.Dispose();
+			_fillBrushRadial = new PathGradientBrush(path)
+			{
+				CenterColor = center,
+				SurroundColors = new Drawing.Color[] { surround }
+			};
+
+			_activeBrush = _fillBrushRadial;
+		}
 
 		public Brush FillBrush
 		{
 			get
 			{
-				if (FillBrushPath != null)
-				{
-					return FillBrushPath;
-				}
+				if (_activeBrush is null)
+					SetFillSolid(FillColor);
 
-				if (FillBrushLinear != null)
-				{
-					return FillBrushLinear;
-				}
-
-				if (FillBrushSolid != null)
-				{
-					FillBrushSolid.Color = FillColor;
-					return FillBrushSolid;
-				}
-
-				FillBrushSolid = new SolidBrush(Drawing.Color.White);
-				return FillBrushSolid;
+				return _activeBrush;
 			}
 		}
 
@@ -256,10 +266,22 @@ namespace Microsoft.Maui.Graphics.GDI
 				_strokePen = null;
 			}
 
-			if (_fillBrush != null)
+			if (_fillBrushSolid != null)
 			{
-				_fillBrush.Dispose();
-				_fillBrush = null;
+				_fillBrushSolid.Dispose();
+				_fillBrushSolid = null;
+			}
+
+			if (_fillBrushLinear != null)
+			{
+				_fillBrushLinear.Dispose();
+				_fillBrushLinear = null;
+			}
+
+			if (_fillBrushRadial != null)
+			{
+				_fillBrushRadial.Dispose();
+				_fillBrushRadial = null;
 			}
 
 			if (_textBrush != null)
@@ -273,10 +295,6 @@ namespace Microsoft.Maui.Graphics.GDI
 				_font.Dispose();
 				_font = null;
 			}
-
-			FillBrushSolid?.Dispose();
-			FillBrushLinear?.Dispose();
-			FillBrushPath?.Dispose();
 
 			base.Dispose();
 		}

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
@@ -138,7 +138,11 @@ namespace Microsoft.Maui.Graphics.GDI
 			set
 			{
 				_fillColor = value;
+
+				FillBrushLinear?.Dispose();
 				FillBrushLinear = null;
+
+				FillBrushPath?.Dispose();
 				FillBrushPath = null;
 			}
 		}
@@ -269,6 +273,10 @@ namespace Microsoft.Maui.Graphics.GDI
 				_font.Dispose();
 				_font = null;
 			}
+
+			FillBrushSolid?.Dispose();
+			FillBrushLinear?.Dispose();
+			FillBrushPath?.Dispose();
 
 			base.Dispose();
 		}


### PR DESCRIPTION
**This PR improves the WinForms GDI control's support for fills using gradient paints.** It's not perfect (GDI support for gradient fills remains limited), but it's an improvement that may be worth considering. Related #44

_EDIT: When filing rectangles with horizontal or vertical linear gradients (perhaps the most common use case, and fully supported by GDI) the appearance is excellent. It would be great if there were some way to at least support this functionality even if the partial functionality for the rest of the fill types is omitted._

* Based on [this comment block](https://github.com/dotnet/Microsoft.Maui.Graphics/blob/992298f82337726c04ccebc8b464d321f1f66d66/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs#L500-L517) I suspect this was supported in the past. 
* [SkiaCanvas.cs SetFillPaint()](https://github.com/dotnet/Microsoft.Maui.Graphics/blob/992298f82337726c04ccebc8b464d321f1f66d66/src/Microsoft.Maui.Graphics.Skia/SkiaCanvas.cs#L283-L443) is a useful reference.
* Linear paints in GDI "wrap around" whereas in Skia they keep going (see screenshots below).
* Radial paint ends at the edge of the gradient rather than filling the whole shape. Achieving the desired outcome may be possible with a rectangular clip, drawing a solid filled rectangle, then drawing the radial shape on top. This means adding extra logic to all fill methods though. I can look into this based on your input.
* Pattern and Image paints remain unsupported.

I'm a bit new here and not sure if your group is looking for these types of contributions at this time (#88) so feel free to do what you want with this, and I welcome any feedback you may have 👍 

## Demonstration

```cs

public class GradientTestDrawing : IDrawable
{
    public void Draw(ICanvas canvas, RectangleF dirtyRect)
    {
        // start with a known solid fill color
        canvas.FillColor = Colors.Maroon;

        // shape 1: linear gradient
        LinearGradientPaint linearPaint = new()
        {
            StartPoint = new Point(0, 0),
            EndPoint = new Point(1, 1),
            StartColor = Colors.Magenta,
            EndColor = Colors.Green,
        };
        Rectangle rect1 = new(10, 10, 100, 50);
        canvas.SetFillPaint(linearPaint, rect1);
        canvas.FillRectangle(rect1);

        // shape 2: solid color
        Rectangle rect2 = new(120, 10, 100, 50);
        canvas.FillColor = Colors.Navy;
        canvas.FillRectangle(rect2);

        // shape 3: linear gradient again
        Rectangle rect3 = new(230, 10, 100, 50);
        canvas.SetFillPaint(linearPaint, rect3);
        canvas.FillRectangle(rect3);

        // shape 4: radial gradient
        RadialGradientPaint radialPaint = new()
        {
            Center = new Point(.5, .5),
            Radius = .5,
            StartColor = Colors.Magenta,
            EndColor = Colors.Green,
        };
        Rectangle rect4 = new(340, 10, 100, 50);
        canvas.SetFillPaint(radialPaint, rect4);
        canvas.FillRectangle(rect4);
    }
}
```

The rectangular gradient fills work great!

Skia | GDI Before | GDI After
---|---|---
![image](https://user-images.githubusercontent.com/4165489/133187590-f5f152ad-7348-4813-9316-0d169718742c.png)|![image](https://user-images.githubusercontent.com/4165489/133182625-083a67de-c155-4b9e-a721-3b4aa9161b35.png)|![image](https://user-images.githubusercontent.com/4165489/133187677-36e243f9-d942-4995-a07d-7efecb25c886.png)

## TestPattern1

Advanced fill gradients reveal GDIs limitations

Skia | GDI Before | GDI After
---|---|--
![testpattern1-skia](https://user-images.githubusercontent.com/4165489/134267745-229a8db5-4505-4b92-bc9b-d548a49f4d33.png)|![testpattern1-gdi-before](https://user-images.githubusercontent.com/4165489/134267744-4566f10f-a974-4bc2-93a4-ffdfea1e3c3a.png)|![testpattern1-gdi-after](https://user-images.githubusercontent.com/4165489/134267738-217a77b3-e532-46a2-ae5d-976cb75191f2.png)

_EDIT: using `WrapMode.TileFlipXY` for linear gradients still isn't perfect, but may be less astonishing than the default tiling behavior seen in the screenshots above:_
![image](https://user-images.githubusercontent.com/4165489/134271939-b858e1ef-1980-42ff-811a-3f58c156c08b.png)

