### PR TITLE
Added System.Numerics.Vectors constructors and operators

### DIFF
--- a/src/Microsoft.Maui.Graphics/AffineTransform.cs
+++ b/src/Microsoft.Maui.Graphics/AffineTransform.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -52,6 +53,16 @@ namespace Microsoft.Maui.Graphics
 			}
 		}
 
+		public AffineTransform(in Matrix3x2 matrix)
+		{
+			_m00 = matrix.M11;
+			_m10 = matrix.M12;
+			_m01 = matrix.M21;
+			_m11 = matrix.M22;
+			_m02 = matrix.M31;
+			_m12 = matrix.M32;
+		}
+
 		public void SetMatrix(float m00, float m10, float m01, float m11, float m02, float m12)
 		{
 			_m00 = m00;
@@ -60,6 +71,16 @@ namespace Microsoft.Maui.Graphics
 			_m11 = m11;
 			_m02 = m02;
 			_m12 = m12;
+		}
+
+		public void SetMatrix(in Matrix3x2 matrix)
+		{
+			_m00 = matrix.M11;
+			_m10 = matrix.M12;
+			_m01 = matrix.M21;
+			_m11 = matrix.M22;
+			_m02 = matrix.M31;
+			_m12 = matrix.M32;
 		}
 
 		public float ScaleX => _m00;
@@ -100,6 +121,16 @@ namespace Microsoft.Maui.Graphics
 			_m11 = m11;
 			_m02 = m02;
 			_m12 = m12;
+		}
+
+		public void SetTransform(in Matrix3x2 matrix)
+		{
+			_m00 = matrix.M11;
+			_m10 = matrix.M12;
+			_m01 = matrix.M21;
+			_m11 = matrix.M22;
+			_m02 = matrix.M31;
+			_m12 = matrix.M32;
 		}
 
 		public void SetTransform(AffineTransform t)
@@ -359,6 +390,13 @@ namespace Microsoft.Maui.Graphics
 		public bool OnlyScale()
 		{
 			return !HasRotate() && !HasTranslate();
+		}
+
+		public static implicit operator AffineTransform(Matrix3x2 matrix) => new AffineTransform(matrix);
+
+		public static explicit operator Matrix3x2(AffineTransform matrix)
+		{
+			return new Matrix3x2(matrix._m00, matrix._m10, matrix._m01, matrix._m11, matrix._m02, matrix._m12);
 		}
 
 		public bool IsIdentity => _m00 == 1.0f && _m11 == 1.0f && _m10 == 0.0f && _m01 == 0.0f && _m02 == 0.0f && _m12 == 0.0f;

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -39,6 +40,14 @@ namespace Microsoft.Maui.Graphics
 			Green = green.Clamp(0, 1);
 			Blue = blue.Clamp(0, 1);
 			Alpha = alpha.Clamp(0, 1);
+		}
+
+		public Color(Vector4 color)
+		{
+			Red = color.X.Clamp(0, 1);
+			Green = color.Y.Clamp(0, 1);
+			Blue = color.Z.Clamp(0, 1);
+			Alpha = color.W.Clamp(0, 1);
 		}
 
 		public override string ToString()
@@ -909,6 +918,8 @@ namespace Microsoft.Maui.Graphics
 
 		static double ParseOpacity(string elem)
 			=> double.Parse(elem, NumberStyles.Number, CultureInfo.InvariantCulture).Clamp(0, 1);
+
+		public static implicit operator Color(Vector4 color) => new Color(color);
 
 	}
 }

--- a/src/Microsoft.Maui.Graphics/Point.cs
+++ b/src/Microsoft.Maui.Graphics/Point.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -36,6 +37,12 @@ namespace Microsoft.Maui.Graphics
 		{
 			X = sz.Width;
 			Y = sz.Height;
+		}
+
+		public Point(Vector2 v)
+		{
+			X = v.X;
+			Y = v.Y;
 		}
 
 		public override bool Equals(object o)
@@ -112,6 +119,8 @@ namespace Microsoft.Maui.Graphics
 		}
 
 		public static implicit operator PointF(Point p) => new PointF((float)p.X, (float)p.Y);
+
+		public static implicit operator Point(Vector2 v) => new Point(v);
 
 		public static bool TryParse(string value, out Point point)
 		{

--- a/src/Microsoft.Maui.Graphics/PointF.cs
+++ b/src/Microsoft.Maui.Graphics/PointF.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -30,6 +31,12 @@ namespace Microsoft.Maui.Graphics
 		{
 			X = sz.Width;
 			Y = sz.Height;
+		}
+
+		public PointF(Vector2 v)
+		{
+			X = v.X;
+			Y = v.Y;
 		}
 
 		public override bool Equals(object o)
@@ -105,6 +112,10 @@ namespace Microsoft.Maui.Graphics
 			y = Y;
 		}
 		public static implicit operator Point(PointF p) => new Point(p.X, p.Y);
+
+		public static implicit operator PointF(Vector2 v) => new PointF(v);
+
+		public static explicit operator Vector2(PointF p) => new Vector2(p.X, p.Y);
 
 		public static bool TryParse(string value, out PointF pointF)
 		{

--- a/src/Microsoft.Maui.Graphics/Size.cs
+++ b/src/Microsoft.Maui.Graphics/Size.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -30,6 +31,16 @@ namespace Microsoft.Maui.Graphics
 				throw new ArgumentException("NaN is not a valid value for height");
 			_width = width;
 			_height = height;
+		}
+
+		public Size(Vector2 vector)
+		{
+			if (float.IsNaN(vector.X))
+				throw new ArgumentException("NaN is not a valid value for X");
+			if (float.IsNaN(vector.Y))
+				throw new ArgumentException("NaN is not a valid value for Y");
+			_width = vector.X;
+			_height = vector.Y;
 		}
 
 		public bool IsZero => _width == 0 && _height == 0;

--- a/src/Microsoft.Maui.Graphics/SizeF.cs
+++ b/src/Microsoft.Maui.Graphics/SizeF.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
 
 namespace Microsoft.Maui.Graphics
 {
@@ -30,6 +31,16 @@ namespace Microsoft.Maui.Graphics
 				throw new ArgumentException("NaN is not a valid value for height");
 			_width = width;
 			_height = height;
+		}
+
+		public SizeF(Vector2 vector)
+		{
+			if (float.IsNaN(vector.X))
+				throw new ArgumentException("NaN is not a valid value for X");
+			if (float.IsNaN(vector.Y))
+				throw new ArgumentException("NaN is not a valid value for Y");
+			_width = vector.X;
+			_height = vector.Y;
 		}
 
 		public bool IsZero => _width == 0 && _height == 0;
@@ -86,6 +97,11 @@ namespace Microsoft.Maui.Graphics
 		public static explicit operator PointF(SizeF size)
 		{
 			return new PointF(size.Width, size.Height);
+		}
+
+		public static explicit operator Vector2(SizeF size)
+		{
+			return new Vector2(size.Width, size.Height);
 		}
 
 		public bool Equals(SizeF other)


### PR DESCRIPTION
Following #136

Added System.Numerics.Vectors constructors and implicit/explicit operator converters to:
- AffineTransform
- Color
- Point
- PointF
- Size
- SizeF

Regarding operators, I followed these rules:
- Vectors to Maui operators are implicit
- Maui to Vectors operators are explicit
- Vectors to Maui (double precission) are implicit
- Maui to Vectors operators (double precission) not implemented to prevent misleading precission loss.