### PR TITLE
Fix test scenario canvas sizes

### DIFF
--- a/samples/GraphicsTester.Portable/Scenarios/DrawImages.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawImages.cs
@@ -6,7 +6,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawImages : AbstractScenario
 	{
 		public DrawImages()
-			: base(720, 1024)
+			: base(1400, 800)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRect.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRect.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawLongTextInRect : AbstractScenario
 	{
 		public DrawLongTextInRect()
-			: base(720, 1024)
+			: base(800, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRectWithOverflow.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRectWithOverflow.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawLongTextInRectWithOverflow : AbstractScenario
 	{
 		public DrawLongTextInRectWithOverflow()
-			: base(720, 1024)
+			: base(800, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRectWithoutOverflow.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawLongTextInRectWithoutOverflow.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawLongTextInRectWithoutOverflow : AbstractScenario
 	{
 		public DrawLongTextInRectWithoutOverflow()
-			: base(720, 1024)
+			: base(800, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawShortTextInRect.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawShortTextInRect.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawShortTextInRect : AbstractScenario
 	{
 		public DrawShortTextInRect()
-			: base(720, 1024)
+			: base(800, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawShortTextInRect2.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawShortTextInRect2.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawShortTextInRect2 : AbstractScenario
 	{
 		public DrawShortTextInRect2()
-			: base(720, 1024)
+			: base(800, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawTextRotatedAtPoint.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawTextRotatedAtPoint.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawTextRotatedAtPoint : AbstractScenario
 	{
 		public DrawTextRotatedAtPoint()
-			: base(720, 1024)
+			: base(1024, 720)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawVerticallyCenteredText.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawVerticallyCenteredText.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawVerticallyCenteredText : AbstractScenario
 	{
 		public DrawVerticallyCenteredText()
-			: base(720, 1024)
+			: base(2000, 2000)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/DrawVerticallyCenteredText2.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawVerticallyCenteredText2.cs
@@ -5,7 +5,7 @@ namespace GraphicsTester.Scenarios
 	public class DrawVerticallyCenteredText2 : AbstractScenario
 	{
 		public DrawVerticallyCenteredText2()
-			: base(720, 1024)
+			: base(2600, 2600)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/MultipleShadowTest.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/MultipleShadowTest.cs
@@ -4,7 +4,7 @@ namespace GraphicsTester.Scenarios
 {
 	public class MultipleShadowTest : AbstractScenario
 	{
-		public MultipleShadowTest() : base(20, 20)
+		public MultipleShadowTest() : base(720, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/SimpleShadowTest.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/SimpleShadowTest.cs
@@ -4,7 +4,7 @@ namespace GraphicsTester.Scenarios
 {
 	public class SimpleShadowTest : AbstractScenario
 	{
-		public SimpleShadowTest() : base(20, 20)
+		public SimpleShadowTest() : base(720, 1024)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/TestPattern1.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/TestPattern1.cs
@@ -4,7 +4,7 @@ namespace GraphicsTester.Scenarios
 {
 	public class TestPattern1 : AbstractScenario
 	{
-		public TestPattern1() : base(720, 1024)
+		public TestPattern1() : base(1000, 1500)
 		{
 		}
 

--- a/samples/GraphicsTester.Portable/Scenarios/TestPattern2.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/TestPattern2.cs
@@ -4,7 +4,7 @@ namespace GraphicsTester.Scenarios
 {
 	public class TestPattern2 : AbstractScenario
 	{
-		public TestPattern2() : base(720, 1024)
+		public TestPattern2() : base(3500, 1700)
 		{
 		}
 


### PR DESCRIPTION
Some scenarios are extremely large and roll-off the test window (#186) or aren't captured in a saved images if the canvas is not properly sized to contain the test drawings. This PR updates canvas dimensions of all the abstract scenarios.