### PR TITLE
[GDI.WinForms] fix rounded rectangles with 0 radius

### DIFF
--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
@@ -238,6 +238,12 @@ namespace Microsoft.Maui.Graphics.GDI
 
 		protected override void NativeDrawRoundedRectangle(float x, float y, float width, float height, float cornerRadius)
 		{
+			if (cornerRadius == 0)
+			{
+				NativeDrawRectangle(x, y, width, height);
+				return;
+			}
+
 			var strokeWidth = CurrentState.StrokeWidth;
 
 			SetRect(x, y, width, height);
@@ -326,6 +332,12 @@ namespace Microsoft.Maui.Graphics.GDI
 
 		public override void FillRoundedRectangle(float x, float y, float width, float height, float cornerRadius)
 		{
+			if (cornerRadius == 0)
+			{
+				FillRectangle(x, y, width, height);
+				return;
+			}
+
 			SetRect(x, y, width, height);
 
 			var path = new GraphicsPath();


### PR DESCRIPTION
This PR improves GDI support for rounded rectangles by preventing exceptions when a radius of 0 is used. Some of the test scenarios test for this, resulting in a crash, and preventing the scenarios from completing. 

Although this PR prevents the exception and allows the tests to complete, rounded rectangles still don't render properly on GDI. I may fix that in a separate PR, but for now not crashing the scenario seems like a good improvement 😅 