### PR TITLE
Refactored AffineTransform towards System.Numerics.Matrix3x2

### DIFF
--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvasState.cs
@@ -374,11 +374,9 @@ namespace Microsoft.Maui.Graphics.GDI
 		}
 
 		public void NativeConcatenateTransform(AffineTransform transform)
-		{
-			_scale *= transform.ScaleX;
-			var values = new float[6];
-			transform.GetMatrix(values);
-			var transformMatrix = new Matrix(values[0], values[1], values[2], values[3], values[4], values[5]);
+		{			
+			_scale *= transform.AverageScaling;			
+			var transformMatrix = new Matrix(transform.M11, transform.M12, transform.M21, transform.M22, transform.M31, transform.M32);
 			_graphics.MultiplyTransform(transformMatrix);
 		}
 	}

--- a/src/Microsoft.Maui.Graphics.Skia/SKGraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/SKGraphicsExtensions.cs
@@ -78,12 +78,12 @@ namespace Microsoft.Maui.Graphics.Skia
 		{
 			var matrix = new SKMatrix
 			{
-				ScaleX = transform.ScaleX,
-				SkewX = transform.ShearX,
-				TransX = transform.TranslateX,
-				SkewY = transform.ShearY,
-				ScaleY = transform.ScaleY,
-				TransY = transform.TranslateY,
+				ScaleX = transform.M11,
+				SkewX = transform.M21,
+				TransX = transform.M31,
+				SkewY = transform.M12,
+				ScaleY = transform.M22,
+				TransY = transform.M32,
 				Persp0 = 0,
 				Persp1 = 0,
 				Persp2 = 1

--- a/src/Microsoft.Maui.Graphics/AbstractCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/AbstractCanvas.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Maui.Graphics
 
 		public void ConcatenateTransform(AffineTransform transform)
 		{
-			_currentState.Scale *= transform.ScaleX;
+			_currentState.Scale *= transform.AverageScaling;
 			_currentState.Transform.Concatenate(transform);
 			NativeConcatenateTransform(transform);
 		}

--- a/src/Microsoft.Maui.Graphics/PointF.cs
+++ b/src/Microsoft.Maui.Graphics/PointF.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Maui.Graphics
 
 		public float Y { get; set; }
 
-		public static PointF Zero = new PointF();
+		public static readonly PointF Zero = new PointF();
 
 		public override string ToString()
 		{

--- a/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
@@ -223,8 +223,9 @@ namespace Microsoft.Maui.Graphics
 
 		public void ConcatenateTransform(AffineTransform transform)
 		{
-			_scaleX *= transform.ScaleX;
-			_scaleY *= transform.ScaleY;
+			var scale = transform.Scaling;
+			_scaleX *= scale.Width;
+			_scaleY *= scale.Height;
 			_canvas.ConcatenateTransform(transform);
 		}
 

--- a/src/Microsoft.Maui.Graphics/SizeF.cs
+++ b/src/Microsoft.Maui.Graphics/SizeF.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Maui.Graphics
 			return new Vector2(size.Width, size.Height);
 		}
 
+		public static explicit operator SizeF(Vector2 size)
+		{
+			return new SizeF(size.X, size.Y);
+		}
+
 		public bool Equals(SizeF other)
 		{
 			return _width.Equals(other._width) && _height.Equals(other._height);
@@ -134,6 +139,7 @@ namespace Microsoft.Maui.Graphics
 			width = Width;
 			height = Height;
 		}
+
 		public static implicit operator Size(SizeF s) => new Size(s.Width, s.Height);
 
 		public static bool TryParse(string value, out SizeF sizeF)

--- a/tests/Microsoft.Maui.Graphics.Tests/AffineTransformTests.cs
+++ b/tests/Microsoft.Maui.Graphics.Tests/AffineTransformTests.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.Maui.Graphics.Tests
+{
+	public class AffineTransformTests
+	{
+		public static IEnumerable<object[]> AffineTransformData()
+		{
+			yield return new object[] { 0, 1, 1 };
+			yield return new object[] { 0, -1, -1 };
+			yield return new object[] { 1, 2, 3 };
+			yield return new object[] { -2, 1, 1 };
+			yield return new object[] { -1, 5, 2 };
+			yield return new object[] { -3, 1, -2 };
+			yield return new object[] { 0, -1, 2 };
+			yield return new object[] { 0, 1, -2 };
+			yield return new object[] { 3, -1, -2 };
+			yield return new object[] { 1, -2, -2 };
+			yield return new object[] { -1, -2, -2 };
+		}
+
+		[Fact]
+		public void TestEquivalence()
+		{
+			// the identity matrix should be equivalent to a matrix
+			// with negative scale and rotated 180 degrees
+
+			var a = new AffineTransform();
+
+			var b = new AffineTransform();
+			b.RotateInDegrees(180);
+			b.Scale(-1, -1);			
+
+			AssertEqual(a, b, 6);
+		}
+
+		[Theory]
+		[MemberData(nameof(AffineTransformData))]
+		public void TestDeconstruct(float rotation, float scaleX, float scaleY)
+		{
+			var translation = new Vector2(5, 9);
+
+			var reference = Matrix3x2.Identity;
+			reference *= Matrix3x2.CreateScale(scaleX, scaleY);
+			reference *= Matrix3x2.CreateRotation(rotation);
+			reference *= Matrix3x2.CreateTranslation(translation);
+			ReferenceDeconstruct(reference, out var refScale, out var refRot, out var refTrans);
+
+			AffineTransform at = reference;
+			at.Deconstruct(out var atTrans, out var atRot, out var atScale);
+
+			AssertEqual(refTrans, atTrans, 5);
+			Assert.Equal(refRot, atRot, 5);
+			AssertEqual(refScale, atScale, 5);
+
+			at = AffineTransform.GetInstance(refTrans, refRot, (SizeF)refScale);
+			AssertEqual(reference, at, 5);
+		}
+
+		[Theory]
+		[MemberData(nameof(AffineTransformData))]
+		public void TestRotationAndScale(float rotation, float scaleX, float scaleY)
+		{
+			var translation = new Vector2(5, 9);
+			
+			var reference = Matrix3x2.Identity;			
+			reference *= Matrix3x2.CreateScale(scaleX, scaleY);
+			reference *= Matrix3x2.CreateRotation(rotation);
+			reference *= Matrix3x2.CreateTranslation(translation);
+
+			ReferenceDeconstruct(reference, out var refScale, out var refRot, out var refTrans);
+
+			// implicit conversion
+
+			AffineTransform at = reference;
+			AssertOrthogonal(at, 7);
+			AssertEqual(reference, at, 9);
+
+			// concatenation
+			// notice that AffineTransform concatenation order
+			// is in reverse order compared to Matrix3x2
+
+			at = new AffineTransform();
+			at.Translate(translation);
+			at.Rotate(rotation);
+			at.Scale(scaleX, scaleY);
+			AssertOrthogonal(at, 7);
+			AssertEqual(reference, at, 7);
+
+			// concatenation and rotate assign
+
+			
+			at = new AffineTransform();
+			at.Translate(translation);
+			at.Scale(scaleX, scaleY);
+			at.Rotation = scaleX >= 0 ? rotation : rotation + (float)Math.PI;
+			AssertOrthogonal(at, 7);
+			AssertEqual(reference, at, 4);			
+
+			// concatenation and scale assign
+			
+			at = new AffineTransform();
+			at.Translate(translation);
+			at.Rotate(rotation);
+			at.Scaling = new SizeF(scaleX, scaleY); // changes scaling without affecting rotation/translation
+			AssertOrthogonal(at, 7);
+			AssertEqual(reference, at, 7);
+
+			// deconstruct/reconstruct
+
+			at = AffineTransform.GetInstance(translation,rotation, new SizeF(scaleX,scaleY) );
+			at.Deconstruct(out var t, out var r, out var s);			
+			at = AffineTransform.GetInstance(t, r, s);
+			AssertOrthogonal(at, 7);
+			AssertEqual(reference, at, 5);
+		}
+
+		[Theory]
+		[MemberData(nameof(AffineTransformData))]
+		public void TestTransformPoint(float rotation, float scaleX, float scaleY)
+		{
+			var translation = new Vector2(5, 9);
+			var point = new Vector2(7, -9);			
+
+			// notice the concatenation order of Matrix3x2 and
+			// AffineTransform are defined in reverse order.
+			var reference = Matrix3x2.Identity;
+			reference *= Matrix3x2.CreateScale(scaleX, scaleY);
+			reference *= Matrix3x2.CreateRotation(rotation);
+			reference *= Matrix3x2.CreateTranslation(translation);
+
+			var pointx = Vector2.Transform(point, reference);
+
+			// create a matrix equivalent to reference.
+
+			var at = new AffineTransform();
+			at.Translate(translation);
+			at.Rotate(rotation);
+			at.Scale(scaleX, scaleY);
+			AssertEqual(reference, at, 5);
+			AssertEqual(pointx, at.Transform(point), 8);
+
+			// create in one shot
+
+			at = AffineTransform.GetInstance(translation, rotation, new SizeF(scaleX,scaleY));
+			AssertEqual(reference, at, 5);
+			AssertEqual(pointx, at.Transform(point), 8);
+
+			// de/reconstruct T R S for roundtrip
+
+			at.Deconstruct(out var t, out var r, out var s);
+			at = AffineTransform.GetInstance(t, r, s);
+			AssertEqual(reference, at, 5);
+			AssertEqual(pointx, at.Transform(point), 4);
+		}		
+
+		private static void AssertEqual(AffineTransform a, AffineTransform b, int precision)
+		{
+			Assert.Equal(a.M11, b.M11, precision);
+			Assert.Equal(a.M21, b.M21, precision);
+			Assert.Equal(a.M31, b.M31, precision);
+			Assert.Equal(a.M12, b.M12, precision);
+			Assert.Equal(a.M22, b.M22, precision);
+			Assert.Equal(a.M32, b.M32, precision);
+		}
+
+		private static void AssertEqual(PointF a, PointF b, int precision)
+		{
+			Assert.Equal(a.X, b.X, precision);
+			Assert.Equal(a.Y, b.Y, precision);
+		}		
+
+		private static void AssertEqual(Vector2 a, SizeF b, int precision)
+		{
+			Assert.Equal(a.X, b.Width, precision);
+			Assert.Equal(a.Y, b.Height, precision);
+		}		
+		
+		private static void AssertOrthogonal(AffineTransform transform, int precission)
+		{
+			var x = Vector2.Normalize(new Vector2(transform.M11, transform.M12));
+			var y = Vector2.Normalize(new Vector2(transform.M21, transform.M22));
+			var d = Vector2.Dot(x, y);			
+			if (d < -1) d = -1;
+			if (d >  1) d =  1;
+
+			var skewAngle = (float) ((Math.PI/2) - Math.Acos(d));
+
+			Assert.Equal(0, skewAngle, precission);
+		}
+
+		private static void ReferenceDeconstruct(Matrix3x2 m, out Vector2 scale, out float rotation, out Vector2 translation)
+		{
+			// Matrix3x2 lacks decompose, but Matrix4x4 has it.
+
+			Matrix4x4.Decompose(new Matrix4x4(m), out var s, out Quaternion r, out var t);
+
+			scale = new Vector2(s.X, s.Y);
+			translation = new Vector2(t.X, t.Y);
+
+			var hand = Vector3.Transform(Vector3.UnitX, r);
+
+			rotation = (float)Math.Atan2(hand.Y, hand.X);
+		}
+	}
+}


### PR DESCRIPTION
- Refactored AffineTransform property names to match those of System.Numerics.Matrix3x2, System.Windows.Media.Matrix and so on.
  - ScaleX, ShearX properties are gone in favour of standarised M11, M12, M21, M22 matrix properties.
- Added Translation, Rotation and Scaling properties to AffineTransform.
  - These properties can be get or set irrespective of the state of the others. Special care has been taken to consider negative scales.
- Added UnitTests for the related changes.
- Added the method Deconstruct to get scale, rotation and translation from an affineTransform. Also added GetInstance to reconstruct an affinetransform with equivalent parameters.
  - It's important to take in account that an orthogonal matrix can be deconstructed into two valid solutions, so while being correct, the deconstructed output TRS does not necessarily need to match the original TRS used to contruct the matrix.

Considerations:

- I've called the scale property "Scaling" instead of "Scale" because a Scale(...) method already exists. I would consider renaming the methods Scale, Rotate and Translate to ConcatenateScale, ConcatenateRotation and ConcatenateTranslation, which would allow renaming "Scaling" to "Scale".
- I've noticed the concatenation order of AffineTransform is in reverse order than of Matrix3x2 , it's fine once you know it, but it tricked me for a while, I'm sure it'll happen the same to others.
- I've noticed in some places ( AbstractCanvas and ScalingCanvas ) the scale was being taken by AffineTransform.M11 (previously ScaleX). I am not completely sure why I'ts needed, but I suspect it's used to get the "average scaling" of the transform, to be used in line thinkness, etc.  using only M11 would have only worked with an unrotated, unscaled matrix. I've introduced the property "AverageScaling" which returns the average scale provided by the transform, irrespective of the axial scales and rotation.
- I've seen methods like SetMatrix(float[]) and Transform(float[] src, int offset, float[] dst...); ... I would seriously consider using System.Memory and changing all the array arguments in *all* the methods to Span<T> and ReadOnlySpan<T>.
- I still dislike having AffineTransform around, I understand it's not possible to replace it by Matrix3x2 at this point... but given that AffineTransform can be converted to Matrix3x2 implicitly if needed, I would replace all the methods taking AffineTransform as input by Matrix3x2, an example of this would be `ICanvas.ConcatenateTransform(AffineTransform transform);` with `ICanvas.ConcatenateTransform(in Matrix3x2 transform);` 

As usual, feel free to add/remove, comment anything you need.... also I humbly request to throughfully test all that code, since it's quite critical stuff....   2D graphics with odd scalings and rotations are quite tricky to handle.


