### PR TITLE
Verify canvas control is unloaded before removing it

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DGraphicsView.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DGraphicsView.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Maui.Graphics.Win2D
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
             // Explicitly remove references to allow the Win2D controls to get garbage collected
-            if (_canvasControl != null)
+            if (_canvasControl != null && !_canvasControl.IsLoaded)
             {
                 _canvasControl.RemoveFromVisualTree();
                 _canvasControl = null;


### PR DESCRIPTION
Because the order of the Loaded/Unloaded events is not guaranteed (see https://github.com/microsoft/microsoft-ui-xaml/issues/1900), removing a W2DGraphicsView from its parent and immediately re-adding it can result in the `UserControl_Unloaded` handler running _after_ the `UserControl_Loaded` handler. This causes the W2DGraphicsView to be removed from the visual tree, and its contents to disappear (https://github.com/dotnet/maui/issues/3214). 

This change adds a check for the CanvasControl's IsLoaded property to verify that the handler is running at a time when the control has actually been unloaded, rather than running out of order. This check can be removed once/if https://github.com/microsoft/microsoft-ui-xaml/issues/1900 is fixed.