### PR TITLE
Rounded rectangle: add support for distinct X and Y radii

### DIFF
--- a/samples/GraphicsTester.Portable/Scenarios/DrawRoundedRectangles.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawRoundedRectangles.cs
@@ -20,6 +20,7 @@ namespace GraphicsTester.Scenarios
 			DrawShadowedRect(canvas);
 			DrawRoundedRectanglesWithDifferentStrokeLocations(canvas);
 			DrawRoundedRectWithZeroAndLargeRadius(canvas);
+			DrawRoundedWithDifferentXYRadius(canvas);
 			canvas.RestoreState();
 
 			canvas.DrawRoundedRectangle(50.5f, 30.5f, 150, 15, 5);
@@ -102,6 +103,12 @@ namespace GraphicsTester.Scenarios
 			canvas.StrokeSize = 1;
 			canvas.DrawRoundedRectangle(250.5f, 700.5f, 150, 20, 0);
 			canvas.DrawRoundedRectangle(450.5f, 700.5f, 150, 20, 50);
+		}
+
+		private void DrawRoundedWithDifferentXYRadius(ICanvas canvas)
+		{
+			RectangleF rect = new RectangleF(275, 400, 100, 100);
+			canvas.DrawRoundedRectangle(rect, xRadius: 20, yRadius: 40);
 		}
 	}
 }

--- a/samples/GraphicsTester.Portable/Scenarios/DrawRoundedRectangles.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawRoundedRectangles.cs
@@ -21,6 +21,7 @@ namespace GraphicsTester.Scenarios
 			DrawRoundedRectanglesWithDifferentStrokeLocations(canvas);
 			DrawRoundedRectWithZeroAndLargeRadius(canvas);
 			DrawRoundedWithDifferentXYRadius(canvas);
+			DrawRoundedWithCircles(canvas);
 			canvas.RestoreState();
 
 			canvas.DrawRoundedRectangle(50.5f, 30.5f, 150, 15, 5);
@@ -107,8 +108,35 @@ namespace GraphicsTester.Scenarios
 
 		private void DrawRoundedWithDifferentXYRadius(ICanvas canvas)
 		{
+			canvas.StrokeColor = Colors.Blue;
+			canvas.StrokeSize = 1;
 			RectangleF rect = new RectangleF(275, 400, 100, 100);
 			canvas.DrawRoundedRectangle(rect, xRadius: 20, yRadius: 40);
+		}
+
+		private void DrawRoundedWithCircles(ICanvas canvas)
+		{
+			float circleRadius = 64;
+
+			canvas.StrokeSize = .5f;
+			canvas.StrokeColor = Colors.Magenta;
+			RectangleF rect = new RectangleF(50, 740, circleRadius * 4, circleRadius * 4);
+			canvas.DrawRoundedRectangle(rect, xRadius: circleRadius, yRadius: circleRadius);
+
+			PointF[] circleCenters =
+			{
+				new PointF(rect.Left + circleRadius, rect.Top + circleRadius),
+				new PointF(rect.Right - circleRadius, rect.Top + circleRadius),
+				new PointF(rect.Left + circleRadius, rect.Bottom - circleRadius),
+				new PointF(rect.Right - circleRadius, rect.Bottom - circleRadius),
+			};
+
+			canvas.StrokeColor = Colors.Green;
+			foreach (PointF circleCenter in circleCenters)
+			{
+				canvas.DrawCircle(circleCenter, circleRadius);
+				canvas.DrawCircle(circleCenter, 1);
+			}
 		}
 	}
 }

--- a/samples/GraphicsTester.Portable/Scenarios/FillRoundedRectangles.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/FillRoundedRectangles.cs
@@ -15,6 +15,7 @@ namespace GraphicsTester.Scenarios
 			FillRoundedRectanglesWithAlpha(canvas);
 			FillShadowedRect(canvas);
 			FillRoundedRectWithZeroAndLargeRadius(canvas);
+			FillRoundedWithDifferentXYRadius(canvas);
 		}
 
 		private static void FillShadowedRect(ICanvas canvas)
@@ -58,6 +59,12 @@ namespace GraphicsTester.Scenarios
 			canvas.FillColor = Colors.Blue;
 			canvas.FillRoundedRectangle(250.5f, 700.5f, 150, 20, 0);
 			canvas.FillRoundedRectangle(450.5f, 700.5f, 150, 20, 50);
+		}
+
+		private void FillRoundedWithDifferentXYRadius(ICanvas canvas)
+		{
+			RectangleF rect = new RectangleF(275, 400, 100, 100);
+			canvas.FillRoundedRectangle(rect, xRadius: 20, yRadius: 40);
 		}
 	}
 }

--- a/src/Microsoft.Maui.Graphics/CanvasExtensions.cs
+++ b/src/Microsoft.Maui.Graphics/CanvasExtensions.cs
@@ -58,6 +58,13 @@ namespace Microsoft.Maui.Graphics
 			target.DrawPath(path);
 		}
 
+		public static void DrawRoundedRectangle(this ICanvas target, RectangleF rect, float xRadius, float yRadius)
+		{
+			var path = new PathF();
+			path.AppendRoundedRectangle(rect, xRadius, yRadius);
+			target.DrawPath(path);
+		}
+
 		public static void FillRoundedRectangle(this ICanvas target, Rectangle rect, double cornerRadius)
 		{
 			target.FillRoundedRectangle((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height, (float)cornerRadius);
@@ -86,6 +93,13 @@ namespace Microsoft.Maui.Graphics
 		{
 			var path = new PathF();
 			path.AppendRoundedRectangle(rect, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius);
+			target.FillPath(path);
+		}
+
+		public static void FillRoundedRectangle(this ICanvas target, RectangleF rect, float xRadius, float yRadius)
+		{
+			var path = new PathF();
+			path.AppendRoundedRectangle(rect, xRadius, yRadius);
 			target.FillPath(path);
 		}
 

--- a/src/Microsoft.Maui.Graphics/PathF.cs
+++ b/src/Microsoft.Maui.Graphics/PathF.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Maui.Graphics
 {
 	public class PathF : IDisposable
 	{
+		private const float K_RATIO = 0.551784777779014f; // ideal ratio of cubic Bezier points for a quarter circle
+
 		private readonly List<float> _arcAngles;
 		private readonly List<bool> _arcClockwise;
 		private readonly List<PointF> _points;
@@ -1033,8 +1035,8 @@ namespace Microsoft.Maui.Graphics
 			var maxY = minY + h;
 			var midX = minX + w / 2;
 			var midY = minY + h / 2;
-			var offsetY = h / 2 * .55f;
-			var offsetX = w / 2 * .55f;
+			var offsetY = h / 2 * K_RATIO;
+			var offsetX = w / 2 * K_RATIO;
 
 			MoveTo(new PointF(minX, midY));
 			CurveTo(new PointF(minX, midY - offsetY), new PointF(midX - offsetX, minY), new PointF(midX, minY));
@@ -1057,8 +1059,8 @@ namespace Microsoft.Maui.Graphics
 			var maxY = cy + r;
 			var midX = cx;
 			var midY = cy;
-			var offsetY = r * .55f;
-			var offsetX = r * .55f;
+			var offsetY = r * K_RATIO;
+			var offsetX = r * K_RATIO;
 
 			MoveTo(new PointF(minX, midY));
 			CurveTo(new PointF(minX, midY - offsetY), new PointF(midX - offsetX, minY), new PointF(midX, minY));
@@ -1107,7 +1109,7 @@ namespace Microsoft.Maui.Graphics
 			var maxX = minX + w;
 			var maxY = minY + h;
 
-			var handleOffset = cornerRadius * .55f;
+			var handleOffset = cornerRadius * K_RATIO;
 			var cornerOffset = cornerRadius - handleOffset;
 
 			MoveTo(new PointF(minX, minY + cornerRadius));
@@ -1142,10 +1144,10 @@ namespace Microsoft.Maui.Graphics
 			float maxX = Math.Max(rect.X, rect.X + rect.Width);
 			float maxY = Math.Max(rect.Y, rect.Y + rect.Height);
 
-			var xHandleOffset = xCornerRadius * .55f;
+			var xHandleOffset = xCornerRadius * K_RATIO;
 			var xCornerOffset = xCornerRadius - xHandleOffset;
 
-			var yHandleOffset = yCornerRadius * .55f;
+			var yHandleOffset = yCornerRadius * K_RATIO;
 			var yCornerOffset = yCornerRadius - yHandleOffset;
 
 			MoveTo(new PointF(minX, minY + yCornerRadius));
@@ -1191,10 +1193,10 @@ namespace Microsoft.Maui.Graphics
 			var maxX = minX + w;
 			var maxY = minY + h;
 
-			var topLeftCornerOffset = topLeftCornerRadius - (topLeftCornerRadius * .55f);
-			var topRightCornerOffset = topRightCornerRadius - (topRightCornerRadius * .55f);
-			var bottomLeftCornerOffset = bottomLeftCornerRadius - (bottomLeftCornerRadius * .55f);
-			var bottomRightCornerOffset = bottomRightCornerRadius - (bottomRightCornerRadius * .55f);
+			var topLeftCornerOffset = topLeftCornerRadius - (topLeftCornerRadius * K_RATIO);
+			var topRightCornerOffset = topRightCornerRadius - (topRightCornerRadius * K_RATIO);
+			var bottomLeftCornerOffset = bottomLeftCornerRadius - (bottomLeftCornerRadius * K_RATIO);
+			var bottomRightCornerOffset = bottomRightCornerRadius - (bottomRightCornerRadius * K_RATIO);
 
 			MoveTo(new PointF(minX, minY + topLeftCornerRadius));
 			CurveTo(new PointF(minX, minY + topLeftCornerOffset), new PointF(minX + topLeftCornerOffset, minY), new PointF(minX + topLeftCornerRadius, minY));

--- a/src/Microsoft.Maui.Graphics/PathF.cs
+++ b/src/Microsoft.Maui.Graphics/PathF.cs
@@ -1132,26 +1132,51 @@ namespace Microsoft.Maui.Graphics
 			AppendRoundedRectangle(rect.X, rect.Y, rect.Width, rect.Height, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius, includeLast);
 		}
 
-		public void AppendRoundedRectangle(RectangleF rect, float xRadius, float yRadius)
+		public void AppendRoundedRectangle(RectangleF rect, float xCornerRadius, float yCornerRadius)
 		{
-			xRadius = Math.Min(xRadius, rect.Width / 2);
-			yRadius = Math.Min(yRadius, rect.Height / 2);
+			xCornerRadius = Math.Min(xCornerRadius, rect.Width / 2);
+			yCornerRadius = Math.Min(yCornerRadius, rect.Height / 2);
 
 			float minX = Math.Min(rect.X, rect.X + rect.Width);
 			float minY = Math.Min(rect.Y, rect.Y + rect.Height);
 			float maxX = Math.Max(rect.X, rect.X + rect.Width);
 			float maxY = Math.Max(rect.Y, rect.Y + rect.Height);
 
-			MoveTo(minX, minY + yRadius);
-			CurveTo(minX, minY + yRadius, minX, minY, minX + xRadius, minY);
-			LineTo(maxX - xRadius, minY);
-			CurveTo(maxX - xRadius, minY, maxX, minY, maxX, minY + yRadius);
-			LineTo(maxX, maxY - yRadius);
-			CurveTo(maxX, maxY - yRadius, maxX, maxY, maxX - xRadius, maxY);
-			LineTo(minX + xRadius, maxY);
-			CurveTo(minX + xRadius, maxY, minX, maxY, minX, maxY - yRadius);
-			LineTo(minX, minY + yRadius);
-			Close();
+			var xHandleOffset = xCornerRadius * .55f;
+			var xCornerOffset = xCornerRadius - xHandleOffset;
+
+			var yHandleOffset = yCornerRadius * .55f;
+			var yCornerOffset = yCornerRadius - yHandleOffset;
+
+			MoveTo(new PointF(minX, minY + yCornerRadius));
+
+			CurveTo(
+				new PointF(minX, minY + yCornerOffset),
+				new PointF(minX + xCornerOffset, minY),
+				new PointF(minX + xCornerRadius, minY));
+
+			LineTo(new PointF(maxX - xCornerRadius, minY));
+
+			CurveTo(
+				new PointF(maxX - xCornerOffset, minY),
+				new PointF(maxX, minY + yCornerOffset),
+				new PointF(maxX, minY + yCornerRadius));
+
+			LineTo(new PointF(maxX, maxY - yCornerRadius));
+
+			CurveTo(
+				new PointF(maxX, maxY - yCornerOffset),
+				new PointF(maxX - xCornerOffset, maxY),
+				new PointF(maxX - xCornerRadius, maxY));
+
+			LineTo(new PointF(minX + xCornerRadius, maxY));
+
+			CurveTo(
+				new PointF(minX + xCornerOffset, maxY),
+				new PointF(minX, maxY - yCornerOffset),
+				new PointF(minX, maxY - yCornerRadius));
+
+			LineTo(new PointF(minX, minY + yCornerRadius));
 		}
 
 		public void AppendRoundedRectangle(float x, float y, float w, float h, float topLeftCornerRadius, float topRightCornerRadius, float bottomLeftCornerRadius, float bottomRightCornerRadius, bool includeLast = false)

--- a/src/Microsoft.Maui.Graphics/PathF.cs
+++ b/src/Microsoft.Maui.Graphics/PathF.cs
@@ -1132,6 +1132,28 @@ namespace Microsoft.Maui.Graphics
 			AppendRoundedRectangle(rect.X, rect.Y, rect.Width, rect.Height, topLeftCornerRadius, topRightCornerRadius, bottomLeftCornerRadius, bottomRightCornerRadius, includeLast);
 		}
 
+		public void AppendRoundedRectangle(RectangleF rect, float xRadius, float yRadius)
+		{
+			xRadius = Math.Min(xRadius, rect.Width / 2);
+			yRadius = Math.Min(yRadius, rect.Height / 2);
+
+			float minX = Math.Min(rect.X, rect.X + rect.Width);
+			float minY = Math.Min(rect.Y, rect.Y + rect.Height);
+			float maxX = Math.Max(rect.X, rect.X + rect.Width);
+			float maxY = Math.Max(rect.Y, rect.Y + rect.Height);
+
+			MoveTo(minX, minY + yRadius);
+			CurveTo(minX, minY + yRadius, minX, minY, minX + xRadius, minY);
+			LineTo(maxX - xRadius, minY);
+			CurveTo(maxX - xRadius, minY, maxX, minY, maxX, minY + yRadius);
+			LineTo(maxX, maxY - yRadius);
+			CurveTo(maxX, maxY - yRadius, maxX, maxY, maxX - xRadius, maxY);
+			LineTo(minX + xRadius, maxY);
+			CurveTo(minX + xRadius, maxY, minX, maxY, minX, maxY - yRadius);
+			LineTo(minX, minY + yRadius);
+			Close();
+		}
+
 		public void AppendRoundedRectangle(float x, float y, float w, float h, float topLeftCornerRadius, float topRightCornerRadius, float bottomLeftCornerRadius, float bottomRightCornerRadius, bool includeLast = false)
 		{
 			topLeftCornerRadius = ClampCornerRadius(topLeftCornerRadius, w, h);


### PR DESCRIPTION
This PR extends `ICanvas` to support drawing and filling rounded rectangles with user-defined horizontal and vertical corner radii by creating a new `DrawRoundedRectangle()` and `FillRoundedRectangle()` overloads that accept `xRadius` and `yRadius`. Lack of this functionality was noted by @wieslawsoltes in #268.

To simplify review I did not modify the existing [`PathF.AppendRoundedRectangle()`](https://github.com/dotnet/Microsoft.Maui.Graphics/blob/20e0e9e8c78d37575c7c0e1a5c64170616085f0a/src/Microsoft.Maui.Graphics/PathF.cs#L1098-L1125) but these two methods could be collapsed into one. If you want me to do this in PR or make any other changes, let me know.

I also added test patterns to demonstrate this new functionality:
`DrawRoundedRectangle()` | `FillRoundedRectangle()`
---|---
![image](https://user-images.githubusercontent.com/4165489/148701615-011d5a64-3198-41f1-b06f-a04afaf6d482.png)|![image](https://user-images.githubusercontent.com/4165489/148701628-86f8c78f-b9a0-4bd8-bbe1-fb6b1a99252f.png)