### PR TITLE
Color: Add obsolete Xamarin.Forms properties

### DIFF
--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -16,6 +16,27 @@ namespace Microsoft.Maui.Graphics
 		public readonly float Blue;
 		public readonly float Alpha = 1;
 
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use Red instead.")]
+		public float R => Red;
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use Green instead.")]
+		public float G => Green;
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use Blue instead.")]
+		public float B => Blue;
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use Alpha instead.")]
+		public float A => Alpha;
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use GetHue() instead.")]
+		public float Hue => GetHue();
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use GetLuminosity() instead.")]
+		public float Luminosity => GetLuminosity();
+
+		[Obsolete("This Xamarin Forms field is obsolete in Maui. Use GetSaturation() instead.")]
+		public float Saturation => GetSaturation();
+
 		public Color()
 		{
 			// Default Black


### PR DESCRIPTION
This PR adds common [properties from `Xamarin.Forms.Color`](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.color?view=xamarin-forms#properties) (`R`, `G`, `B`, `A`, `Hue`, `Saturation`, `Luminosity`) to `Maui.Graphics.Color` to make migration easier.

These properties are marked obsolete with messages indicating their replacements. 

Originally suggested by @davidbritch in #280

Related: #31, #32