### PR TITLE
Point distance

### DIFF
--- a/src/Microsoft.Maui.Graphics/Point.cs
+++ b/src/Microsoft.Maui.Graphics/Point.cs
@@ -92,6 +92,11 @@ namespace Microsoft.Maui.Graphics
 			return new Point(pt.X + sz.Width, pt.Y + sz.Height);
 		}
 
+		public static Size operator -(Point ptA, Point ptB)
+		{
+			return new Size(ptA.X - ptB.X, ptA.Y - ptB.Y);
+		}
+
 		public static Point operator -(Point pt, SizeF sz)
 		{
 			return new Point(pt.X - sz.Width, pt.Y - sz.Height);

--- a/src/Microsoft.Maui.Graphics/PointF.cs
+++ b/src/Microsoft.Maui.Graphics/PointF.cs
@@ -91,6 +91,11 @@ namespace Microsoft.Maui.Graphics
 			return new PointF(pt.X + sz.Width, pt.Y + sz.Height);
 		}
 
+		public static SizeF operator -(PointF ptA, PointF ptB)
+		{
+			return new SizeF(ptA.X - ptB.X, ptA.Y - ptB.Y);
+		}
+
 		public static PointF operator -(PointF pt, SizeF sz)
 		{
 			return new PointF(pt.X - sz.Width, pt.Y - sz.Height);

--- a/src/Microsoft.Maui.Graphics/Size.cs
+++ b/src/Microsoft.Maui.Graphics/Size.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Maui.Graphics
 			return new Size(s1._width * value, s1._height * value);
 		}
 
+		public static Size operator /(Size s1, double value)
+		{
+			return new Size(s1._width / value, s1._height / value);
+		}
+
 		public static bool operator ==(Size s1, Size s2)
 		{
 			return s1._width == s2._width && s1._height == s2._height;

--- a/src/Microsoft.Maui.Graphics/SizeF.cs
+++ b/src/Microsoft.Maui.Graphics/SizeF.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Maui.Graphics
 			return new SizeF(s1._width * value, s1._height * value);
 		}
 
+		public static SizeF operator /(SizeF s1, float value)
+		{
+			return new SizeF(s1._width / value, s1._height / value);
+		}
+
 		public static bool operator ==(SizeF s1, SizeF s2)
 		{
 			return s1._width == s2._width && s1._height == s2._height;


### PR DESCRIPTION
### Description
This PR adds a few operators to make doing calculations with points and sizes easier and more natural.

The biggest addition is the subtration of two points which results in a size. This makes it a lot easier to calculate distances/vectors between two points. This is similar to how subtracting `DateTime` from `DateTime` results in a `TimeSpan`

It also adds operators to divide a size by a scalar. There was already an operator for multiplying by a scalar, but the division operator was missing.

### Example use case
The use case where I ran into these operators missing is when I tried to calculate a point halfway between two points:
`c = a + (b - a) / 2`

### Added operators
`Point - Point -> Size`
`PointF - PointF -> SizeF`
`Size / double -> Size`
`SizeF / float -> SizeF`