### PR TITLE
ScalingCanvas: DrawPath, FillPath, and ClipPath respect distinct X and Y scales

### DIFF
--- a/samples/GraphicsTester.Portable/Scenarios/DrawPathsScaled.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/DrawPathsScaled.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Maui.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphicsTester.Scenarios
+{
+	internal class DrawPathsScaled : AbstractScenario
+	{
+		public DrawPathsScaled() : base(720, 1024)
+		{
+		}
+
+		public override void Draw(ICanvas canvas)
+		{
+			DrawScaledPaths(canvas);
+		}
+
+		private void DrawScaledPaths(ICanvas canvas)
+		{
+			PathF path = new(100, 100);
+			path.AddArc(100, 100, 200, 200, 0, 180, true);
+			path.LineTo(150, 100);
+			path.Close();
+
+			canvas.StrokeColor = Colors.Black;
+			canvas.DrawPath(path);
+
+			canvas.StrokeColor = Colors.Magenta;
+			canvas.DrawPath(path.AsScaledPath(1.5f));
+
+			canvas.StrokeColor = Colors.Green;
+			canvas.DrawPath(path.AsScaledPath(0.5f, 1f));
+
+			canvas.StrokeColor = Colors.Orange;
+			canvas.DrawPath(path.AsScaledPath(1f, 0.5f));
+		}
+	}
+}

--- a/samples/GraphicsTester.Portable/Scenarios/ScaleCanvas.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/ScaleCanvas.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Maui.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphicsTester.Scenarios
+{
+	internal class ScaleCanvas : AbstractScenario
+	{
+		public ScaleCanvas() : base(720, 1024)
+		{
+		}
+
+		public override void Draw(ICanvas canvas)
+		{
+			DrawTestShapesOnScaledCanvas(canvas, 1, 1, Colors.Black);
+			DrawTestShapesOnScaledCanvas(canvas, 2, 2, Colors.Magenta);
+			DrawTestShapesOnScaledCanvas(canvas, 2, 1, Colors.Green);
+			DrawTestShapesOnScaledCanvas(canvas, 1, 2, Colors.Orange);
+		}
+
+		private void DrawTestShapesOnScaledCanvas(ICanvas canvas, float xScale, float yScale, Color color)
+		{
+			PathF path = new(100, 100);
+			path.AddArc(100, 100, 200, 200, 0, 180, true);
+			path.LineTo(150, 100);
+			path.Close();
+
+			canvas.SaveState();
+			canvas.Scale(xScale, yScale);
+			canvas.StrokeColor = color;
+			canvas.StrokeSize = 2;
+			canvas.DrawPath(path);
+			canvas.RestoreState();
+		}
+	}
+}

--- a/samples/GraphicsTester.Portable/Scenarios/ScenarioList.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/ScenarioList.cs
@@ -24,6 +24,7 @@ namespace GraphicsTester.Scenarios
 						new ArcScenario1(true),
 						new ArcScenario2(),
 						new DrawPaths(),
+						new DrawPathsScaled(),
 						new DrawFlattenedPaths(),
 						new DrawImages(),
 						new DrawTextAtPoint(),

--- a/samples/GraphicsTester.Portable/Scenarios/ScenarioList.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/ScenarioList.cs
@@ -61,6 +61,7 @@ namespace GraphicsTester.Scenarios
 						new ClipRect(),
 						new SubtractFromClip(),
 						new DimensionTest(),
+						new ScaleCanvas(),
 					};
 				}
 

--- a/src/Microsoft.Maui.Graphics/PathExtensions.cs
+++ b/src/Microsoft.Maui.Graphics/PathExtensions.cs
@@ -72,5 +72,16 @@ namespace Microsoft.Maui.Graphics
 			scaledPath.Transform(transform);
 			return scaledPath;
 		}
+
+		public static PathF AsScaledPath(
+			this PathF target,
+			float xScale,
+			float yScale)
+		{
+			var scaledPath = new PathF(target);
+			var transform = Matrix3x2.CreateScale(xScale, yScale);
+			scaledPath.Transform(transform);
+			return scaledPath;
+		}
 	}
 }

--- a/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/ScalingCanvas.cs
@@ -175,19 +175,19 @@ namespace Microsoft.Maui.Graphics
 
 		public void DrawPath(PathF path)
 		{
-			var scaledPath = path.AsScaledPath(_scaleX);
+			var scaledPath = path.AsScaledPath(_scaleX, _scaleY);
 			_canvas.DrawPath(scaledPath);
 		}
 
 		public void FillPath(PathF path, WindingMode windingMode)
 		{
-			var scaledPath = path.AsScaledPath(_scaleX);
+			var scaledPath = path.AsScaledPath(_scaleX, _scaleY);
 			_canvas.FillPath(scaledPath, windingMode);
 		}
 
 		public void ClipPath(PathF path, WindingMode windingMode = WindingMode.NonZero)
 		{
-			var scaledPath = path.AsScaledPath(_scaleX);
+			var scaledPath = path.AsScaledPath(_scaleX, _scaleY);
 			_canvas.ClipPath(scaledPath, windingMode);
 		}
 


### PR DESCRIPTION
@mgierlasinski noted in #302 that paths currently can only be scaled evenly by a single number, and that in the `ScaledCanvas` module only the X scale is used. This PR resolves this issue by:

* Adding a `PathF.AsScaledPath()` overload that accepts distinct X and Y scales
* Updating `ScaledCanvas` methods `DrawPath`, `FillPath`, and `ClipPath` to use the new overload
* Adding some graphics test scenarios to demonstrate this behavior

### Test scenario demonstrating the fix

```cs
DrawTestShapesOnScaledCanvas(canvas, 1, 1, Colors.Black);
DrawTestShapesOnScaledCanvas(canvas, 2, 2, Colors.Magenta);
DrawTestShapesOnScaledCanvas(canvas, 2, 1, Colors.Green);
DrawTestShapesOnScaledCanvas(canvas, 1, 2, Colors.Orange);
```

```cs
private void DrawTestShapesOnScaledCanvas(ICanvas canvas, float xScale, float yScale, Color color)
{
	PathF path = new(100, 100);
	path.AddArc(100, 100, 200, 200, 0, 180, true);
	path.LineTo(150, 100);
	path.Close();

	canvas.SaveState();
	canvas.Scale(xScale, yScale);
	canvas.StrokeColor = color;
	canvas.StrokeSize = 2;
	canvas.DrawPath(path);
	canvas.RestoreState();
}
```

before | after
---|---
![scaled-canvas-before](https://user-images.githubusercontent.com/4165489/152651063-346f0293-befe-451f-be74-b412f6eae791.png)|![scaled-canvas-after](https://user-images.githubusercontent.com/4165489/152651061-8105a550-f4a5-4d15-bcba-094a121e108f.png)

