### PR TITLE
Color: add overloads so `int` does not get clamped like a `float`

### DIFF
--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -267,10 +267,20 @@ namespace Microsoft.Maui.Graphics
 
 		public static Color FromRgb(byte red, byte green, byte blue)
 		{
-			return Color.FromRgba(red, green, blue, 255);
+			return new Color(red / 255f, green / 255f, blue / 255f, 1f);
 		}
 
 		public static Color FromRgba(byte red, byte green, byte blue, byte alpha)
+		{
+			return new Color(red / 255f, green / 255f, blue / 255f, alpha / 255f);
+		}
+
+		public static Color FromRgb(int red, int green, int blue)
+		{
+			return new Color(red / 255f, green / 255f, blue / 255f, 1f);
+		}
+
+		public static Color FromRgba(int red, int green, int blue, int alpha)
 		{
 			return new Color(red / 255f, green / 255f, blue / 255f, alpha / 255f);
 		}

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Maui.Graphics
 			Alpha = alpha.Clamp(0, 1);
 		}
 
+		public Color(int red, int green, int blue)
+		{
+			Red = (red / 255f).Clamp(0, 255);
+			Green = (green / 255f).Clamp(0, 255);
+			Blue = (blue / 255f).Clamp(0, 255);
+			Alpha = 1.0f;
+		}
+
+		public Color(int red, int green, int blue, int alpha)
+		{
+			Red = (red / 255f).Clamp(0, 255);
+			Green = (green / 255f).Clamp(0, 255);
+			Blue = (blue / 255f).Clamp(0, 255);
+			Alpha = (alpha / 255f).Clamp(0, 255);
+		}
+
 		public Color(Vector4 color)
 		{
 			Red = color.X.Clamp(0, 1);

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -44,34 +44,34 @@ namespace Microsoft.Maui.Graphics
 
 		public Color(byte red, byte green, byte blue)
 		{
-			Red = (red / 255f).Clamp(0, 255);
-			Green = (green / 255f).Clamp(0, 255);
-			Blue = (blue / 255f).Clamp(0, 255);
+			Red = (red / 255f).Clamp(0, 1);
+			Green = (green / 255f).Clamp(0, 1);
+			Blue = (blue / 255f).Clamp(0, 1);
 			Alpha = 1.0f;
 		}
 
 		public Color(byte red, byte green, byte blue, byte alpha)
 		{
-			Red = (red / 255f).Clamp(0, 255);
-			Green = (green / 255f).Clamp(0, 255);
-			Blue = (blue / 255f).Clamp(0, 255);
-			Alpha = (alpha / 255f).Clamp(0, 255);
+			Red = (red / 255f).Clamp(0, 1);
+			Green = (green / 255f).Clamp(0, 1);
+			Blue = (blue / 255f).Clamp(0, 1);
+			Alpha = (alpha / 255f).Clamp(0, 1);
 		}
 
 		public Color(int red, int green, int blue)
 		{
-			Red = (red / 255f).Clamp(0, 255);
-			Green = (green / 255f).Clamp(0, 255);
-			Blue = (blue / 255f).Clamp(0, 255);
+			Red = (red / 255f).Clamp(0, 1);
+			Green = (green / 255f).Clamp(0, 1);
+			Blue = (blue / 255f).Clamp(0, 1);
 			Alpha = 1.0f;
 		}
 
 		public Color(int red, int green, int blue, int alpha)
 		{
-			Red = (red / 255f).Clamp(0, 255);
-			Green = (green / 255f).Clamp(0, 255);
-			Blue = (blue / 255f).Clamp(0, 255);
-			Alpha = (alpha / 255f).Clamp(0, 255);
+			Red = (red / 255f).Clamp(0, 1);
+			Green = (green / 255f).Clamp(0, 1);
+			Blue = (blue / 255f).Clamp(0, 1);
+			Alpha = (alpha / 255f).Clamp(0, 1);
 		}
 
 		public Color(Vector4 color)

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Maui.Graphics
 			Alpha = alpha.Clamp(0, 1);
 		}
 
+		public Color(byte red, byte green, byte blue)
+		{
+			Red = (red / 255f).Clamp(0, 255);
+			Green = (green / 255f).Clamp(0, 255);
+			Blue = (blue / 255f).Clamp(0, 255);
+			Alpha = 1.0f;
+		}
+
+		public Color(byte red, byte green, byte blue, byte alpha)
+		{
+			Red = (red / 255f).Clamp(0, 255);
+			Green = (green / 255f).Clamp(0, 255);
+			Blue = (blue / 255f).Clamp(0, 255);
+			Alpha = (alpha / 255f).Clamp(0, 255);
+		}
+
 		public Color(int red, int green, int blue)
 		{
 			Red = (red / 255f).Clamp(0, 255);

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Maui.Graphics
 		public Color()
 		{
 			// Default Black
-			Red = Green = Blue = 0;	
+			Red = Green = Blue = 0;
 		}
 
 		public Color(float gray)


### PR DESCRIPTION
This PR adds overloads for the `Color` constructor, `FromRgb()`, and `FromRgba()` that accept `int`.

Reported by @PureWeen in #253 and @davidbritch in #308, there exists a problem where `int` values (expected to be 0-255) are interpreted as `float` and clamped between 0 and 1.0, demonstrated here:

```cs
// fill a circle with a random color using a fluent method
canvas.FillColor = Color.FromRgba(rand.Next(0, 255), rand.Next(0, 255), rand.Next(0, 255), rand.Next(100, 200));
canvas.FillCircle(pt1, radius);

// fill a circle with a random color using a constructor
canvas.FillColor = new Color(rand.Next(0, 255), rand.Next(0, 255), rand.Next(0, 255), rand.Next(100, 200));
canvas.FillCircle(pt2, radius);
```

<details>
<summary>Full source code</summary>

```cs
using Microsoft.Maui.Graphics;
using Microsoft.Maui.Graphics.Skia;

Random rand = new(0);
using BitmapExportContext bmp = new SkiaBitmapExportContext(300, 200, 1.0f);
ICanvas canvas = bmp.Canvas;

// draw a test pattern in the background
canvas.FillColor = Colors.DarkGray;
canvas.FillRectangle(0, 0, bmp.Width, bmp.Height);
canvas.StrokeSize = 3;
canvas.StrokeColor = Colors.Black;
for (int i = 0; i < bmp.Width * 2; i += 50)
    canvas.DrawLine(0, i, i, 0);

// define a pair of circles
PointF pt1 = new(100, 100);
PointF pt2 = new(200, 100);
float radius = 75;

// fill a circle with a random color using a fluent method
canvas.FillColor = Color.FromRgba(rand.Next(0, 255), rand.Next(0, 255), rand.Next(0, 255), rand.Next(100, 200));
canvas.FillCircle(pt1, radius);

// fill a circle with a random color using a constructor
canvas.FillColor = new Color(rand.Next(0, 255), rand.Next(0, 255), rand.Next(0, 255), rand.Next(100, 200));
canvas.FillCircle(pt2, radius);

string filePath = Path.GetFullPath("test.png");
using FileStream fs = new(filePath, FileMode.Create);
bmp.WriteToStream(fs);
Console.WriteLine(filePath);
```

</details>

Original Behavior | New Behavior
---|---
![before](https://user-images.githubusercontent.com/4165489/152889558-f1f1bb8c-d489-40d2-9ad6-7d9a6673a5dd.png)|![after](https://user-images.githubusercontent.com/4165489/152889557-246b35f5-8b08-473a-9409-eaa83b71613d.png)