### PR TITLE
SBOM: Fix for conditional logic based on signingCondition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
   signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
-  unsignedCondition: and(succeeded('windows'),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))))
+  unsignedCondition: and(succeeded('windows'),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )))))
 
 parameters:
   - name: BuildConfigurations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
   signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
-  unsignedCondition: and(succeeded('windows'),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )))))
+  unsignedCondition: and(succeeded(),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))))
 
 parameters:
   - name: BuildConfigurations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,7 +222,7 @@ stages:
           artifactMap: ['nuget/Release']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: not(${{ variables['signingCondition'] }})                    # Executed when signing is not enabled such as for PRs
+          condition: not(${{ variables['signingCondition'] }})                    # Executed when signing is not enabled such as for pull request builds (PRs)
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -232,4 +232,4 @@ stages:
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: and(succeeded(), ${{ variables['signingCondition'] }} )      # Executed when signing is enabled such as for CIs
+          condition: and(succeeded(), ${{ variables['signingCondition'] }} )      # Executed when signing is enabled such as for continuous integration builds (CIs)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/main # still defaults to master even though main is the main branch
+      ref: refs/heads/dev/bond/sbom-update    # UNDONE: DO NOT MERGE TO MAIN
 
 stages:
   - stage: windows
@@ -211,6 +211,8 @@ stages:
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
+          jobName: SBOM_PR
+          jobDisplayName: 'Software Bill of Materials (PR)'
           artifactNames: ['nuget']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
@@ -218,6 +220,8 @@ stages:
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
+          jobName: SBOM_CI
+          jobDisplayName: 'Software Bill of Materials (CI)'
           artifactNames: ['nuget']
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,15 +207,15 @@ stages:
 
     - stage: sbom
       displayName: 'Software Bill of Materials'
-      ${{ if not(variables['signingCondition']) }}:
+      $[ if not(variables['signingCondition']) ]:
         dependsOn: [ 'windows' ]
-      ${{ if variables['signingCondition'] }}:
+      $[ if variables['signingCondition'] ]:
         dependsOn: [ 'nuget_signing' ]
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
           artifactNames: ['nuget']
-          ${{ if variables['signingCondition'] }}:
+          $[ if variables['signingCondition'] ]:
             artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ variables:
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
   signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
+  unsignedCondition: and(succeeded('windows'),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))))
 
 parameters:
   - name: BuildConfigurations
@@ -216,7 +217,7 @@ stages:
           artifactNames: ['nuget']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: ${{ eq(variables['signingCondition'], false) }}      # Executed when signing is not enabled such as for PRs
+          condition: ${{ variables['unsignedCondition'] }}      # Executed when signing is not enabled such as for PRs
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
   signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
-  unsignedCondition: and(succeeded(),not(and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))))
+  unsignedCondition: and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
 
 parameters:
   - name: BuildConfigurations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,15 +207,23 @@ stages:
 
     - stage: sbom
       displayName: 'Software Bill of Materials'
-      $[ if not(variables['signingCondition']) ]:
-        dependsOn: [ 'windows' ]
-      $[ if variables['signingCondition'] ]:
-        dependsOn: [ 'nuget_signing' ]
+      dependsOn: [ 'windows' ]
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
           artifactNames: ['nuget']
-          $[ if variables['signingCondition'] ]:
-            artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
+          condition: ${{ not(variables['signingCondition']) }}
+
+    - stage: sbom
+      displayName: 'Software Bill of Materials'
+      dependsOn: [ 'nuget_signing' ]
+      jobs:
+      - template: compliance/sbom/job.v1.yml@xamarin-templates
+        parameters:
+          artifactNames: ['nuget']
+          artifactMap: ['nuget/signed']
+          packageName: 'Microsoft Maui Graphics'
+          packageFilter: '*.nupkg'
+          condition: ${{ variables['signingCondition'] }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-      ref: refs/heads/dev/bond/sbom-update    # UNDONE: DO NOT MERGE TO MAIN
+      ref: refs/heads/main
 
 stages:
   - stage: windows
@@ -221,7 +221,7 @@ stages:
           artifactMap: ['nuget/Release']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: and(succeeded('windows'), not(${{ variables['signingCondition'] }}))                # Executed when signing is not enabled such as for PRs
+          condition: and(succeeded('windows'), not(${{ variables['signingCondition'] }})) # Executed when signing is not enabled such as for PRs
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -231,4 +231,4 @@ stages:
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: and(succeeded(), ${{ variables['signingCondition'] }} )  # Executed when signing is enabled such as for CIs
+          condition: and(succeeded(), ${{ variables['signingCondition'] }} )              # Executed when signing is enabled such as for CIs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,8 @@ stages:
 
     - stage: sbom
       displayName: 'Software Bill of Materials'
-      dependsOn: [ 'nuget_signing' ]
+      dependsOn: [ 'windows', 'nuget_signing' ]
+      condition: succeeded('windows')
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -221,7 +222,7 @@ stages:
           artifactMap: ['nuget/Release']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: and(succeeded('windows'), not(${{ variables['signingCondition'] }})) # Executed when signing is not enabled such as for PRs
+          condition: not(${{ variables['signingCondition'] }})                    # Executed when signing is not enabled such as for PRs
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -231,4 +232,4 @@ stages:
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: and(succeeded(), ${{ variables['signingCondition'] }} )              # Executed when signing is enabled such as for CIs
+          condition: and(succeeded(), ${{ variables['signingCondition'] }} )      # Executed when signing is enabled such as for CIs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,20 +205,21 @@ stages:
             displayName: Sign Phase
             condition: ${{ variables['signingCondition'] }}
 
-    - stage: sbom
-      displayName: 'Software Bill of Materials'
+    - stage: sbomPR
+      displayName: 'Software Bill of Materials (PR)'
       dependsOn: [ 'windows' ]
+      condition: ${{ not(variables['signingCondition']) }}
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
           artifactNames: ['nuget']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: ${{ not(variables['signingCondition']) }}
 
-    - stage: sbom
-      displayName: 'Software Bill of Materials'
+    - stage: sbomCI
+      displayName: 'Software Bill of Materials (CI)'
       dependsOn: [ 'nuget_signing' ]
+      condition: ${{ variables['signingCondition'] }}
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -226,4 +227,3 @@ stages:
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: ${{ variables['signingCondition'] }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,19 +6,11 @@ variables:
   provisionator.path: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
-  signingCondition: and(succeeded(),
-                        or(eq(variables['Sign'], 'true'),
-                           or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-                              or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )
-                             )
+  signingCondition: or(eq(variables['Sign'], 'true'),
+                       or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+                          or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )
                           )
-                       )
-  unsignedCondition: not(or(eq(variables['Sign'], 'true'),
-                           or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),
-                              or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )
-                             )
-                           )
-                        )
+                      )
 
 parameters:
   - name: BuildConfigurations
@@ -215,7 +207,7 @@ stages:
             signedArtifactName: nuget
             signedArtifactPath: signed
             displayName: Sign Phase
-            condition: ${{ variables['signingCondition'] }}
+            condition: and(succeeded(), ${{ variables['signingCondition'] }} )
 
     - stage: sbom
       displayName: 'Software Bill of Materials'
@@ -226,9 +218,10 @@ stages:
           jobName: SBOM_PR
           jobDisplayName: 'Software Bill of Materials (PR)'
           artifactNames: ['nuget']
+          artifactMap: ['nuget/Release']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: ${{ variables['unsignedCondition'] }}      # Executed when signing is not enabled such as for PRs
+          condition: not(${{ variables['signingCondition'] }})                # Executed when signing is not enabled such as for PRs
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
@@ -238,4 +231,4 @@ stages:
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: ${{ variables['signingCondition'] }}                 # Executed when signing is enabled such as for CIs
+          condition: and(succeeded(), ${{ variables['signingCondition'] }} )  # Executed when signing is enabled such as for CIs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,7 +221,7 @@ stages:
           artifactMap: ['nuget/Release']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
-          condition: not(${{ variables['signingCondition'] }})                # Executed when signing is not enabled such as for PRs
+          condition: and(succeeded('windows'), not(${{ variables['signingCondition'] }}))                # Executed when signing is not enabled such as for PRs
 
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,19 @@ variables:
   provisionator.path: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
   provisionator.extraArguments: '--v'
-  signingCondition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
-  unsignedCondition: and(or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') ))))
+  signingCondition: and(succeeded(),
+                        or(eq(variables['Sign'], 'true'),
+                           or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+                              or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )
+                             )
+                          )
+                       )
+  unsignedCondition: not(or(eq(variables['Sign'], 'true'),
+                           or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+                              or(startsWith(variables['Build.SourceBranch'],'refs/tags/'),  startsWith(variables['Build.SourceBranch'],'refs/heads/release/') )
+                             )
+                           )
+                        )
 
 parameters:
   - name: BuildConfigurations

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,25 +205,21 @@ stages:
             displayName: Sign Phase
             condition: ${{ variables['signingCondition'] }}
 
-    - stage: sbomPR
-      displayName: 'Software Bill of Materials (PR)'
-      dependsOn: [ 'windows' ]
-      condition: ${{ not(variables['signingCondition']) }}
+    - stage: sbom
+      displayName: 'Software Bill of Materials'
+      dependsOn: [ 'nuget_signing' ]
       jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
           artifactNames: ['nuget']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
+          condition: ${{ eq(variables['signingCondition'], false) }}      # Executed when signing is not enabled such as for PRs
 
-    - stage: sbomCI
-      displayName: 'Software Bill of Materials (CI)'
-      dependsOn: [ 'nuget_signing' ]
-      condition: ${{ variables['signingCondition'] }}
-      jobs:
       - template: compliance/sbom/job.v1.yml@xamarin-templates
         parameters:
           artifactNames: ['nuget']
           artifactMap: ['nuget/signed']
           packageName: 'Microsoft Maui Graphics'
           packageFilter: '*.nupkg'
+          condition: ${{ variables['signingCondition'] }}                 # Executed when signing is enabled such as for CIs


### PR DESCRIPTION
Follow up fix for https://github.com/dotnet/Microsoft.Maui.Graphics/pull/314

Related work item: VS #[1477663](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1477663)

The signing conditions applied to settings within the SBOM stage are being evaluated too early at the time the YAML file is being "compiled".  We instead need a solution where SBOM configuration settings are applied once the signing condition evaluated at YAML "run time".

Depends on https://github.com/xamarin/yaml-templates/pull/174