### PR TITLE
Renamed Geometry class to GeometryUtil

### DIFF
--- a/samples/GraphicsTester.Portable/Scenarios/TransformRotateFromOrigin.cs
+++ b/samples/GraphicsTester.Portable/Scenarios/TransformRotateFromOrigin.cs
@@ -29,7 +29,7 @@ namespace GraphicsTester.Scenarios
 			var point = new PointF(65, 65);
 			for (int i = -3; i < 3; i++)
 			{
-				var rotated = Geometry.RotatePoint(point, -15 * i);
+				var rotated = GeometryUtil.RotatePoint(point, -15 * i);
 				canvas.DrawLine(rotated.X - 10, rotated.Y, rotated.X + 10, rotated.Y);
 				canvas.DrawLine(rotated.X, rotated.Y - 10, rotated.X, rotated.Y + 10);
 			}

--- a/src/Microsoft.Maui.Graphics.Blazor/BlazorCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Blazor/BlazorCanvas.cs
@@ -424,8 +424,8 @@ namespace Microsoft.Maui.Graphics.Blazor
 					float endAngle = target.GetArcAngle(arcAngleIndex++);
 					var clockwise = target.GetArcClockwise(arcClockwiseIndex++);
 
-					var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-					var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+					var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+					var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 					while (startAngleInRadians < 0)
 					{

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDICanvas.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Maui.Graphics.GDI
 				endAngle += 360;
 			}
 
-			float sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			float sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			SetRect(x, y, width, height);
 			if (!clockwise)
 			{
@@ -212,7 +212,7 @@ namespace Microsoft.Maui.Graphics.GDI
 				endAngle += 360;
 			}
 
-			float sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			float sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			SetRect(x, y, width, height);
 			if (!clockwise)
 			{

--- a/src/Microsoft.Maui.Graphics.GDI.Winforms/GDIExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.GDI.Winforms/GDIExtensions.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Maui.Graphics.GDI
 						var width = (bottomRight.X - topLeft.X) * ppux;
 						var height = (bottomRight.Y - topLeft.Y) * ppuy;
 
-						float sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+						float sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 						if (!clockwise)
 						{
 							startAngle = endAngle;

--- a/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXCanvas.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Maui.Graphics.SharpDX
 				endAngle += 360;
 			}
 
-			var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absRotation = Math.Abs(rotation);
 
 			float strokeWidth = CurrentState.StrokeSize;
@@ -275,8 +275,8 @@ namespace Microsoft.Maui.Graphics.SharpDX
 			_size.Width = _rect.Width / 2;
 			_size.Height = _rect.Height / 2;
 
-			var startPoint = Geometry.EllipseAngleToPoint(_rect.X, _rect.Y, _rect.Width, _rect.Height, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(_rect.X, _rect.Y, _rect.Width, _rect.Height, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(_rect.X, _rect.Y, _rect.Width, _rect.Height, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(_rect.X, _rect.Y, _rect.Width, _rect.Height, -endAngle);
 
 			_point1.X = startPoint.X;
 			_point1.Y = startPoint.Y;
@@ -317,14 +317,14 @@ namespace Microsoft.Maui.Graphics.SharpDX
 				endAngle += 360;
 			}
 
-			var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absRotation = Math.Abs(rotation);
 
 			_size.Width = width / 2;
 			_size.Height = height / 2;
 
-			var startPoint = Geometry.EllipseAngleToPoint(x, y, width, height, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(x, y, width, height, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(x, y, width, height, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(x, y, width, height, -endAngle);
 
 			_point1.X = startPoint.X;
 			_point1.Y = startPoint.Y;

--- a/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXCanvasState.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Maui.Graphics.SharpDX
 						else if (_sourceFillpaint is RadialGradientPaint radialGradientPaint)
 						{
 							if(_radialGradientRadius == 0)
-							 _radialGradientRadius = Geometry.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
+							 _radialGradientRadius = GeometryUtil.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
 
 							var radialGradientBrushProperties = new RadialGradientBrushProperties();
 							var gradientStops = new global::SharpDX.Direct2D1.GradientStop[radialGradientPaint.GradientStops.Length];
@@ -635,14 +635,14 @@ namespace Microsoft.Maui.Graphics.SharpDX
 
 		public Matrix3x2 DxRotate(float aAngle)
 		{
-			float radians = Geometry.DegreesToRadians(aAngle);
+			float radians = GeometryUtil.DegreesToRadians(aAngle);
 			Matrix = Matrix.Rotate(radians);
 			return Matrix;
 		}
 
 		public Matrix3x2 DxRotate(float aAngle, float x, float y)
 		{
-			float radians = Geometry.DegreesToRadians(aAngle);
+			float radians = GeometryUtil.DegreesToRadians(aAngle);
 			Matrix = Matrix.Translate(x, y);
 			Matrix = Matrix.Rotate(radians);
 			Matrix = Matrix.Translate(-x, -y);

--- a/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.SharpDX.Shared/DXExtensions.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Maui.Graphics.SharpDX
 							endAngle += 360;
 						}
 
-						var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+						var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 						var absRotation = Math.Abs(rotation);
 
 						var rectX = ox + topLeft.X * ppux;
@@ -135,8 +135,8 @@ namespace Microsoft.Maui.Graphics.SharpDX
 						var rectWidth = (ox + bottomRight.X * ppux) - rectX;
 						var rectHeight = (oy + bottomRight.Y * ppuy) - rectY;
 
-						var startPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
-						var endPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
+						var startPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
+						var endPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
 
 
 						if (!figureOpen)

--- a/src/Microsoft.Maui.Graphics.Skia/SKGraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/SKGraphicsExtensions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Maui.Graphics.Skia
 					}
 
 					var rect = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 					startAngle *= -1;
 					if (!clockwise)
@@ -246,7 +246,7 @@ namespace Microsoft.Maui.Graphics.Skia
 				}
 
 				var rect = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
-				var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+				var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 				startAngle *= -1;
 				if (!clockwise)
@@ -322,7 +322,7 @@ namespace Microsoft.Maui.Graphics.Skia
 					}
 
 					var rect = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 					startAngle *= -1;
 					if (!clockwise)

--- a/src/Microsoft.Maui.Graphics.Skia/SkiaCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/SkiaCanvas.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Maui.Graphics.Skia
 				float radius = (float)radialGradientPaint.Radius * Math.Max(rectangle.Height, rectangle.Width);
 
 				if (radius == 0)
-					radius = Geometry.GetDistance(rectangle.Left, rectangle.Top, rectangle.Right, rectangle.Bottom);
+					radius = GeometryUtil.GetDistance(rectangle.Left, rectangle.Top, rectangle.Right, rectangle.Bottom);
 
 				try
 				{
@@ -413,7 +413,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			var rectWidth = width;
 			var rectHeight = height;
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 			var rect = new SKRect(rectX, rectY, rectX + rectWidth, rectY + rectHeight);
 
@@ -457,7 +457,7 @@ namespace Microsoft.Maui.Graphics.Skia
 			while (endAngle < 0)
 				endAngle += 360;
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var rect = new SKRect(x, y, x + width, y + height);
 
 			startAngle *= -1;

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
@@ -158,7 +158,7 @@ After:
 				endAngle += 360;
 			}
 
-			var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absRotation = Math.Abs(rotation);
 
 			float strokeWidth = CurrentState.StrokeSize;
@@ -167,8 +167,8 @@ After:
 			_size.Width = _rect.Width / 2;
 			_size.Height = _rect.Height / 2;
 
-			var startPoint = Geometry.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -endAngle);
 
 			_point1.X = startPoint.X;
 			_point1.Y = startPoint.Y;
@@ -546,7 +546,7 @@ After:
 				endAngle += 360;
 			}
 
-			var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absRotation = Math.Abs(rotation);
 
 			float strokeWidth = CurrentState.StrokeSize;
@@ -555,8 +555,8 @@ After:
 			_size.Width = _rect.Width / 2;
 			_size.Height = _rect.Height / 2;
 
-			var startPoint = Geometry.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint((float)_rect.X, (float)_rect.Y, (float)_rect.Width, (float)_rect.Height, -endAngle);
 
 			_point1.X = startPoint.X;
 			_point1.Y = startPoint.Y;

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvasState.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Maui.Graphics.Win2D
 						}
 						else if (_sourceFillpaint is RadialGradientPaint radialGradientPaint)
 						{
-							//float radius = Geometry.GetDistance(_gradientPoint1.X, _gradientPoint1.Y, _gradientPoint2.X, _gradientPoint2.Y);
+							//float radius = GeometryUtil.GetDistance(_gradientPoint1.X, _gradientPoint1.Y, _gradientPoint2.X, _gradientPoint2.Y);
 
 							var gradientStops = new CanvasGradientStop[radialGradientPaint.GradientStops.Length];
 							for (int i = 0; i < radialGradientPaint.GradientStops.Length; i++)
@@ -437,14 +437,14 @@ namespace Microsoft.Maui.Graphics.Win2D
 
 		public Matrix3x2 AppendRotate(float aAngle)
 		{
-			float radians = Geometry.DegreesToRadians(aAngle);
+			float radians = GeometryUtil.DegreesToRadians(aAngle);
 			Matrix = Matrix.Rotate(radians);
 			return Matrix;
 		}
 
 		public Matrix3x2 AppendRotate(float aAngle, float x, float y)
 		{
-			float radians = Geometry.DegreesToRadians(aAngle);
+			float radians = GeometryUtil.DegreesToRadians(aAngle);
 			Matrix = Matrix.Translate(x, y);
 			Matrix = Matrix.Rotate(radians);
 			Matrix = Matrix.Translate(-x, -y);

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Graphics.Win2D
 							endAngle += 360;
 						}
 
-						var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+						var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 						var absRotation = Math.Abs(rotation);
 
 						var rectX = ox + topLeft.X * fx;
@@ -143,8 +143,8 @@ namespace Microsoft.Maui.Graphics.Win2D
 						var rectWidth = (ox + bottomRight.X * fx) - rectX;
 						var rectHeight = (oy + bottomRight.Y * fy) - rectY;
 
-						var startPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
-						var endPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
+						var startPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
+						var endPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
 
 
 						if (!figureOpen)
@@ -257,7 +257,7 @@ namespace Microsoft.Maui.Graphics.Win2D
 					endAngle += 360;
 				}
 
-				var rotation = Geometry.GetSweep(startAngle, endAngle, clockwise);
+				var rotation = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 				var absRotation = Math.Abs(rotation);
 
 				var rectX = topLeft.X * scale;
@@ -265,8 +265,8 @@ namespace Microsoft.Maui.Graphics.Win2D
 				var rectWidth = (bottomRight.X * scale) - rectX;
 				var rectHeight = (bottomRight.Y * scale) - rectY;
 
-				var startPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
-				var endPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
+				var startPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
+				var endPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
 
 				builder.BeginFigure(startPoint.X * scale, startPoint.Y * scale, CanvasFigureFill.Default);
 

--- a/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvas.cs
@@ -374,10 +374,10 @@ namespace Microsoft.Maui.Graphics.Xaml
 			var figure = geometry.Figures[0];
 			var arcSegment = (ArcSegment)figure.Segments[0];
 
-			var sweep = Geometry.GetSweep(startAngle,endAngle,clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle,endAngle,clockwise);
 			var absSweep = Math.Abs(sweep);
-			var startPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
 
 			figure.StartPoint = new global::Windows.Foundation.Point(startPoint.X, startPoint.Y);
 			arcSegment.Point = new global::Windows.Foundation.Point(endPoint.X, endPoint.Y);
@@ -763,10 +763,10 @@ namespace Microsoft.Maui.Graphics.Xaml
 			var figure = geometry.Figures[0];
 			var arcSegment = (ArcSegment)figure.Segments[0];
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absSweep = Math.Abs(sweep);
-			var startPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
 
 			figure.StartPoint = new global::Windows.Foundation.Point(startPoint.X, startPoint.Y);
 			arcSegment.Point = new global::Windows.Foundation.Point(endPoint.X, endPoint.Y);

--- a/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlCanvasState.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Maui.Graphics.Xaml
  						float radius = (float)radialGradientPaint.Radius * Math.Max(_fillRectangle.Height, _fillRectangle.Width);
 
 						if (radius == 0)
-							radius = Geometry.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
+							radius = GeometryUtil.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
 
 						var brush = new RadialGradientBrush();
 						brush.MappingMode = BrushMappingMode.Absolute;

--- a/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlGraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.UWP/XamlGraphicsExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Maui.Graphics.Xaml
 						endAngle += 360;
 					}
 
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 					var absSweep = Math.Abs(sweep);
 
 					var rectX = topLeft.X * scale;
@@ -112,8 +112,8 @@ namespace Microsoft.Maui.Graphics.Xaml
 					var rectWidth = bottomRight.X * scale - topLeft.X * scale;
 					var rectHeight = bottomRight.Y * scale - topLeft.Y * scale;
 
-					var startPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
-					var endPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
+					var startPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
+					var endPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
 
 					if (figure == null)
 					{

--- a/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvas.cs
@@ -375,10 +375,10 @@ namespace Microsoft.Maui.Graphics.Xaml
 			var figure = geometry.Figures[0];
 			var arcSegment = (ArcSegment) figure.Segments[0];
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absSweep = Math.Abs(sweep);
-			var startPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
 
 			figure.StartPoint = new global::System.Windows.Point(startPoint.X, startPoint.Y);
 			arcSegment.Point = new global::System.Windows.Point(endPoint.X, endPoint.Y);
@@ -793,10 +793,10 @@ namespace Microsoft.Maui.Graphics.Xaml
 			var figure = geometry.Figures[0];
 			var arcSegment = (ArcSegment) figure.Segments[0];
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var absSweep = Math.Abs(sweep);
-			var startPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
-			var endPoint = Geometry.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
+			var startPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -startAngle);
+			var endPoint = GeometryUtil.EllipseAngleToPoint(_rectX, _rectY, _rectWidth, _rectHeight, -endAngle);
 
 			figure.StartPoint = new global::System.Windows.Point(startPoint.X, startPoint.Y);
 			arcSegment.Point = new global::System.Windows.Point(endPoint.X, endPoint.Y);

--- a/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlCanvasState.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.Graphics.Xaml
 						float radius = (float)radialGradientPaint.Radius * Math.Max(_fillRectangle.Height, _fillRectangle.Width);
 
 						if (radius == 0)
-							radius = Geometry.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
+							radius = GeometryUtil.GetDistance(_fillRectangle.Left, _fillRectangle.Top, _fillRectangle.Right, _fillRectangle.Bottom);
 
 						var brush = new RadialGradientBrush { MappingMode = BrushMappingMode.Absolute };
 						brush.GradientOrigin = brush.Center = new System.Windows.Point(centerX, centerY);
@@ -240,7 +240,7 @@ namespace Microsoft.Maui.Graphics.Xaml
 							BlurRadius = _shadowBlur,
 							Color = _shadowColor.AsWpfColor(),
 							Opacity = Alpha * .5,
-							Direction = Geometry.GetAngleAsDegrees(0, 0, _shadowOffset.Width, _shadowOffset.Height)
+							Direction = GeometryUtil.GetAngleAsDegrees(0, 0, _shadowOffset.Width, _shadowOffset.Height)
 						};
 					}
 

--- a/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlGraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics.Xaml.WPF/XamlGraphicsExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Maui.Graphics.Xaml
 						endAngle += 360;
 					}
 
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 					var absSweep = Math.Abs(sweep);
 
 					var rectX = topLeft.X * scale;
@@ -99,8 +99,8 @@ namespace Microsoft.Maui.Graphics.Xaml
 					var rectWidth = bottomRight.X * scale - topLeft.X * scale;
 					var rectHeight = bottomRight.Y * scale - topLeft.Y * scale;
 
-					var startPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
-					var endPoint = Geometry.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
+					var startPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -startAngle);
+					var endPoint = GeometryUtil.EllipseAngleToPoint(rectX, rectY, rectWidth, rectHeight, -endAngle);
 
 					if (figure == null)
 					{

--- a/src/Microsoft.Maui.Graphics/AbstractCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/AbstractCanvas.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Maui.Graphics
 
 		public void Rotate(float degrees, float x, float y)
 		{
-			var radians = Geometry.DegreesToRadians(degrees);
+			var radians = GeometryUtil.DegreesToRadians(degrees);
 
 			var transform = _currentState.Transform;
 			transform = Matrix3x2.CreateTranslation(x, y) * transform;
@@ -272,7 +272,7 @@ namespace Microsoft.Maui.Graphics
 
 		public void Rotate(float degrees)
 		{
-			var radians = Geometry.DegreesToRadians(degrees);
+			var radians = GeometryUtil.DegreesToRadians(degrees);
 
 			var transform = _currentState.Transform;			
 			transform = Matrix3x2.CreateRotation(radians) * transform;			

--- a/src/Microsoft.Maui.Graphics/Android/GraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics/Android/GraphicsExtensions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Maui.Graphics.Platform
 					}
 
 					var rect = new global::Android.Graphics.RectF(offsetX + topLeft.X * scaleX, offsetY + topLeft.Y * scaleY, offsetX + bottomRight.X * scaleX, offsetY + bottomRight.Y * scaleY);
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 					startAngle *= -1;
 					if (!clockwise)
@@ -226,7 +226,7 @@ namespace Microsoft.Maui.Graphics.Platform
 				}
 
 				var rect = new global::Android.Graphics.RectF(topLeft.X * ppu, topLeft.Y * ppu, bottomRight.X * ppu, bottomRight.Y * ppu);
-				var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+				var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 				startAngle *= -1;
 				if (!clockwise)
@@ -304,7 +304,7 @@ namespace Microsoft.Maui.Graphics.Platform
 					}
 
 					var rect = new global::Android.Graphics.RectF(topLeft.X * ppu, topLeft.Y * ppu, bottomRight.X * ppu, bottomRight.Y * ppu);
-					var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+					var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 					startAngle *= -1;
 					if (!clockwise)

--- a/src/Microsoft.Maui.Graphics/Android/PlatformCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/Android/PlatformCanvas.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Maui.Graphics.Platform
 				float radius = (float)radialGradientPaint.Radius * Math.Max(rectangle.Height, rectangle.Width);
 
 				if (radius == 0)
-					radius = Geometry.GetDistance(rectangle.Left, rectangle.Top, rectangle.Right, rectangle.Bottom);
+					radius = GeometryUtil.GetDistance(rectangle.Left, rectangle.Top, rectangle.Right, rectangle.Bottom);
 
 				try
 				{
@@ -389,7 +389,7 @@ namespace Microsoft.Maui.Graphics.Platform
 			var rectWidth = width;
 			var rectHeight = height;
 
-			float sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			float sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 
 			var rect = new global::Android.Graphics.RectF(rectX, rectY, rectX + rectWidth, rectY + rectHeight);
 
@@ -434,7 +434,7 @@ namespace Microsoft.Maui.Graphics.Platform
 				endAngle += 360;
 			}
 
-			var sweep = Geometry.GetSweep(startAngle, endAngle, clockwise);
+			var sweep = GeometryUtil.GetSweep(startAngle, endAngle, clockwise);
 			var rect = new global::Android.Graphics.RectF(x, y, x + width, y + height);
 
 			startAngle *= -1;

--- a/src/Microsoft.Maui.Graphics/ArcFlattener.cs
+++ b/src/Microsoft.Maui.Graphics/ArcFlattener.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Maui.Graphics
 
             angle *= -1;
 
-            var radians = (float)Geometry.DegreesToRadians(angle);
+            var radians = (float)GeometryUtil.DegreesToRadians(angle);
             var point = GetPointAtAngle(0, 0, _radius, radians);
             point.X = _cx + (point.X * _fx);
             point.Y = _cy + (point.Y * _fy);
@@ -89,7 +89,7 @@ namespace Microsoft.Maui.Graphics
                 if (endPoint == null)
                     endPoint = GetPointOnArc(candidate);
                 var midPointOnLine = GetCenter(_startPoint, (PointF)endPoint);
-                if (Geometry.GetDistance(midPointOnArc.X, midPointOnArc.Y, midPointOnLine.X, midPointOnLine.Y) <= flatness)
+                if (GeometryUtil.GetDistance(midPointOnArc.X, midPointOnArc.Y, midPointOnLine.X, midPointOnLine.Y) <= flatness)
                 {
                     found = true;
                     n = n << 1;

--- a/src/Microsoft.Maui.Graphics/Color.cs
+++ b/src/Microsoft.Maui.Graphics/Color.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Maui.Graphics
 
 		public Color WithAlpha(float alpha)
 		{
-			if (Math.Abs(alpha - Alpha) < Geometry.Epsilon)
+			if (Math.Abs(alpha - Alpha) < GeometryUtil.Epsilon)
 				return this;
 
 			return new Color(Red, Green, Blue, alpha);

--- a/src/Microsoft.Maui.Graphics/GeometryUtil.cs
+++ b/src/Microsoft.Maui.Graphics/GeometryUtil.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Microsoft.Maui.Graphics
 {
-	public static class Geometry
+	public static class GeometryUtil
 	{
 		public const float Epsilon = 0.0000000001f;
 
@@ -13,8 +13,6 @@ namespace Microsoft.Maui.Graphics
 
 			return (float) Math.Sqrt(a * a + b * b);
 		}
-
-
 
 		public static float GetAngleAsDegrees(float x1, float y1, float x2, float y2)
 		{

--- a/src/Microsoft.Maui.Graphics/GradientPaint.cs
+++ b/src/Microsoft.Maui.Graphics/GradientPaint.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Maui.Graphics
 			{
 				var currentOffset = stops[i].Offset;
 
-				if (Math.Abs(currentOffset - offset) < Geometry.Epsilon)
+				if (Math.Abs(currentOffset - offset) < GeometryUtil.Epsilon)
 				{
 					return stops[i].Color;
 				}
@@ -228,7 +228,7 @@ namespace Microsoft.Maui.Graphics
 				return StartColor;
 			}
 
-			var f = Geometry.GetFactor(before, after, offset);
+			var f = GeometryUtil.GetFactor(before, after, offset);
 			return BlendStartAndEndColors(stops[beforeIndex].Color, stops[afterIndex].Color, f);
 		}
 
@@ -247,10 +247,10 @@ namespace Microsoft.Maui.Graphics
 			startColor ??= Colors.White;
 			endColor ??= Colors.White;
 
-			var r = Geometry.GetLinearValue(startColor.Red, endColor.Red, factor);
-			var g = Geometry.GetLinearValue(startColor.Green, endColor.Green, factor);
-			var b = Geometry.GetLinearValue(startColor.Blue, endColor.Blue, factor);
-			var a = Geometry.GetLinearValue(startColor.Alpha, endColor.Alpha, factor);
+			var r = GeometryUtil.GetLinearValue(startColor.Red, endColor.Red, factor);
+			var g = GeometryUtil.GetLinearValue(startColor.Green, endColor.Green, factor);
+			var b = GeometryUtil.GetLinearValue(startColor.Blue, endColor.Blue, factor);
+			var a = GeometryUtil.GetLinearValue(startColor.Alpha, endColor.Alpha, factor);
 
 			return new Color(r, g, b, a);
 		}

--- a/src/Microsoft.Maui.Graphics/Insets.cs
+++ b/src/Microsoft.Maui.Graphics/Insets.cs
@@ -58,16 +58,16 @@ namespace Microsoft.Maui.Graphics
 
 		public bool AllValuesAreEqualTo(double value)
 		{
-			return Math.Abs(_top - value) < Geometry.Epsilon && Math.Abs(_left - value) < Geometry.Epsilon && Math.Abs(_right - value) < Geometry.Epsilon &&
-				   Math.Abs(_bottom - value) < Geometry.Epsilon;
+			return Math.Abs(_top - value) < GeometryUtil.Epsilon && Math.Abs(_left - value) < GeometryUtil.Epsilon && Math.Abs(_right - value) < GeometryUtil.Epsilon &&
+				   Math.Abs(_bottom - value) < GeometryUtil.Epsilon;
 		}
 
 		public override bool Equals(object obj)
 		{
 			if (obj is Insets vCompareTo)
 			{
-				return Math.Abs(vCompareTo.Top - Top) < Geometry.Epsilon && Math.Abs(vCompareTo.Left - Left) < Geometry.Epsilon && Math.Abs(vCompareTo.Bottom - Bottom) < Geometry.Epsilon &&
-					   Math.Abs(vCompareTo.Right - Right) < Geometry.Epsilon;
+				return Math.Abs(vCompareTo.Top - Top) < GeometryUtil.Epsilon && Math.Abs(vCompareTo.Left - Left) < GeometryUtil.Epsilon && Math.Abs(vCompareTo.Bottom - Bottom) < GeometryUtil.Epsilon &&
+					   Math.Abs(vCompareTo.Right - Right) < GeometryUtil.Epsilon;
 			}
 
 			return false;

--- a/src/Microsoft.Maui.Graphics/InsetsF.cs
+++ b/src/Microsoft.Maui.Graphics/InsetsF.cs
@@ -58,16 +58,16 @@ namespace Microsoft.Maui.Graphics
 
 		public bool AllValuesAreEqualTo(float value)
 		{
-			return Math.Abs(_top - value) < Geometry.Epsilon && Math.Abs(_left - value) < Geometry.Epsilon && Math.Abs(_right - value) < Geometry.Epsilon &&
-				   Math.Abs(_bottom - value) < Geometry.Epsilon;
+			return Math.Abs(_top - value) < GeometryUtil.Epsilon && Math.Abs(_left - value) < GeometryUtil.Epsilon && Math.Abs(_right - value) < GeometryUtil.Epsilon &&
+				   Math.Abs(_bottom - value) < GeometryUtil.Epsilon;
 		}
 
 		public override bool Equals(object obj)
 		{
 			if (obj is InsetsF vCompareTo)
 			{
-				return Math.Abs(vCompareTo.Top - Top) < Geometry.Epsilon && Math.Abs(vCompareTo.Left - Left) < Geometry.Epsilon && Math.Abs(vCompareTo.Bottom - Bottom) < Geometry.Epsilon &&
-					   Math.Abs(vCompareTo.Right - Right) < Geometry.Epsilon;
+				return Math.Abs(vCompareTo.Top - Top) < GeometryUtil.Epsilon && Math.Abs(vCompareTo.Left - Left) < GeometryUtil.Epsilon && Math.Abs(vCompareTo.Bottom - Bottom) < GeometryUtil.Epsilon &&
+					   Math.Abs(vCompareTo.Right - Right) < GeometryUtil.Epsilon;
 			}
 
 			return false;

--- a/src/Microsoft.Maui.Graphics/MaciOS/GraphicsExtensions.cs
+++ b/src/Microsoft.Maui.Graphics/MaciOS/GraphicsExtensions.cs
@@ -130,8 +130,8 @@ namespace Microsoft.Maui.Graphics.Platform
 					float endAngle = target.GetArcAngle(arcAngleIndex++);
 					var clockwise = target.GetArcClockwise(arcClockwiseIndex++);
 
-					var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-					var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+					var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+					var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 					while (startAngleInRadians < 0)
 					{
@@ -219,8 +219,8 @@ namespace Microsoft.Maui.Graphics.Platform
 				var endAngle = target.GetArcAngle(arcAngleIndex++);
 				var clockwise = target.GetArcClockwise(arcClockwiseIndex++);
 
-				var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-				var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+				var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+				var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 				while (startAngleInRadians < 0)
 				{
@@ -299,8 +299,8 @@ namespace Microsoft.Maui.Graphics.Platform
 					float endAngle = target.GetArcAngle(arcAngleIndex++);
 					var clockwise = target.GetArcClockwise(arcClockwiseIndex++);
 
-					var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-					var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+					var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+					var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 					while (startAngleInRadians < 0)
 					{
@@ -318,7 +318,7 @@ namespace Microsoft.Maui.Graphics.Platform
 					var height = bottomRight.Y - topLeft.Y;
 					var r = width / 2;
 
-					var rotatedCenter = Geometry.RotatePoint(center, new PointF(cx, cy), angle);
+					var rotatedCenter = GeometryUtil.RotatePoint(center, new PointF(cx, cy), angle);
 
 					var transform = CGAffineTransform.MakeTranslation(rotatedCenter.X * ppu, rotatedCenter.Y * ppu);
 					transform = CGAffineTransform.Multiply(CGAffineTransform.MakeScale(1, height / width), transform);

--- a/src/Microsoft.Maui.Graphics/MaciOS/PlatformCanvas.cs
+++ b/src/Microsoft.Maui.Graphics/MaciOS/PlatformCanvas.cs
@@ -407,8 +407,8 @@ namespace Microsoft.Maui.Graphics.Platform
 			_rect.Height = height;
 
 			if (!_antialias) _context.SetShouldAntialias(false);
-			var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-			var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+			var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+			var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 			while (startAngleInRadians < 0)
 				startAngleInRadians += (float) Math.PI * 2;
@@ -455,8 +455,8 @@ namespace Microsoft.Maui.Graphics.Platform
 			_rect.Width = width;
 			_rect.Height = height;
 
-			var startAngleInRadians = Geometry.DegreesToRadians(-startAngle);
-			var endAngleInRadians = Geometry.DegreesToRadians(-endAngle);
+			var startAngleInRadians = GeometryUtil.DegreesToRadians(-startAngle);
+			var endAngleInRadians = GeometryUtil.DegreesToRadians(-endAngle);
 
 			while (startAngleInRadians < 0)
 				startAngleInRadians += (float) Math.PI * 2;

--- a/src/Microsoft.Maui.Graphics/PathArcExtensions.cs
+++ b/src/Microsoft.Maui.Graphics/PathArcExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Maui.Graphics
 			float dy2 = (lastPointY - y) / 2.0f;
 
 			// Convert angle from degrees to radians
-			angle = Geometry.DegreesToRadians(angle);
+			angle = GeometryUtil.DegreesToRadians(angle);
 			float cosAngle = (float) Math.Cos(angle);
 			float sinAngle = (float) Math.Sin(angle);
 
@@ -76,13 +76,13 @@ namespace Microsoft.Maui.Graphics
 
 			sign = uy < 0 ? -1.0f : 1.0f;
 
-			float angleStart = Geometry.RadiansToDegrees(sign * (float) Math.Acos(p / n));
+			float angleStart = GeometryUtil.RadiansToDegrees(sign * (float) Math.Acos(p / n));
 
 			// Compute the angle extent
 			n = (float) Math.Sqrt((ux * ux + uy * uy) * (vx * vx + vy * vy));
 			p = ux * vx + uy * vy;
 			sign = ux * vy - uy * vx < 0 ? -1.0f : 1.0f;
-			float angleExtent = Geometry.RadiansToDegrees(sign * (float) Math.Acos(p / n));
+			float angleExtent = GeometryUtil.RadiansToDegrees(sign * (float) Math.Acos(p / n));
 
 			if (!sweepFlag && angleExtent > 0)
 			{
@@ -118,13 +118,13 @@ namespace Microsoft.Maui.Graphics
 			// Now calculate the sweep of each segment
 			float segAngle = arc / segs;
 
-			float theta = Geometry.DegreesToRadians(segAngle);
-			float angle = Geometry.DegreesToRadians(startAngle);
+			float theta = GeometryUtil.DegreesToRadians(segAngle);
+			float angle = GeometryUtil.DegreesToRadians(startAngle);
 
 			// Draw as 45 degree segments
 			if (segs > 0)
 			{
-				float beta = Geometry.DegreesToRadians(xAxisRotation);
+				float beta = GeometryUtil.DegreesToRadians(xAxisRotation);
 				float sinbeta = (float) Math.Sin(beta);
 				float cosbeta = (float) Math.Cos(beta);
 

--- a/src/Microsoft.Maui.Graphics/PathBuilder.cs
+++ b/src/Microsoft.Maui.Graphics/PathBuilder.cs
@@ -539,11 +539,11 @@ namespace Microsoft.Maui.Graphics
 			if (_lastCurveControlPoint == null && _relativePoint != null)
 			{
 				// ReSharper restore ConvertIfStatementToNullCoalescingExpression
-				point1 = Geometry.GetOppositePoint((PointF)_relativePoint, point2);
+				point1 = GeometryUtil.GetOppositePoint((PointF)_relativePoint, point2);
 			}
 			else if (_relativePoint != null && _lastCurveControlPoint != null)
 			{
-				point1 = Geometry.GetOppositePoint((PointF)_relativePoint, (PointF)_lastCurveControlPoint);
+				point1 = GeometryUtil.GetOppositePoint((PointF)_relativePoint, (PointF)_lastCurveControlPoint);
 			}
 
 			var point3 = NewPoint(NextValue, NextValue, isRelative, true);

--- a/src/Microsoft.Maui.Graphics/PathF.cs
+++ b/src/Microsoft.Maui.Graphics/PathF.cs
@@ -919,7 +919,7 @@ namespace Microsoft.Maui.Graphics
 		public PointF GetRotatedPoint(int pointIndex, PointF pivotPoint, float angle)
 		{
 			var point = _points[pointIndex];
-			return Geometry.RotatePoint(pivotPoint, point, angle);
+			return GeometryUtil.RotatePoint(pivotPoint, point, angle);
 		}
 
 		public void Transform(Matrix3x2 transform)
@@ -1298,7 +1298,7 @@ namespace Microsoft.Maui.Graphics
 				for (var i = 0; i < _points.Count; i++)
 				{
 					var point = _points[i];
-					if (!point.Equals(compareTo[i], Geometry.Epsilon))
+					if (!point.Equals(compareTo[i], GeometryUtil.Epsilon))
 						return false;
 				}
 
@@ -1307,7 +1307,7 @@ namespace Microsoft.Maui.Graphics
 					for (var i = 0; i < _arcAngles.Count; i++)
 					{
 						var arcAngle = _arcAngles[i];
-						if (Math.Abs(arcAngle - compareTo.GetArcAngle(i)) > Geometry.Epsilon)
+						if (Math.Abs(arcAngle - compareTo.GetArcAngle(i)) > GeometryUtil.Epsilon)
 							return false;
 					}
 				}


### PR DESCRIPTION
It's not necessary, as it can't conflict with the .NET MAUI Geometry class in XAML, but to avoid possible confusion we renamed the Geometry class from Graphics to **GeometryUtil**.