### PR TITLE
Lower supported version for windows

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</AssemblyName>
     <LangVersion>10.0</LangVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For fixing CA1416 warnings found in windows build in MAUI repo, like:

```log
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DGraphicsView' is only supported on 'Windows'   10.0.18362.0 and later.
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DGraphicsView.Drawable' is only supported on   'Windows' 10.0.18362.0 and later.
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DGraphicsView.Drawable' is only supported on   'Windows' 10.0.18362.0 and later.
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DGraphicsView.Invalidate()' is only supported on   'Windows' 10.0.18362.0 and later.
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DExtensions.AsPath(PathF, ICanvasResourceCreator,   CanvasFilledRegionDetermination)' is only supported on 'Windows' 10.0.18362.0   and later.
This call site is reachable on 'Windows'   10.0.17763.0 and later. 'W2DGraphicsView.Invalidate()' is only supported on   'Windows' 10.0.18362.0 and later.
```

Related to https://github.com/dotnet/maui/issues/823