### PR TITLE
Bump WindowsAppSdk and Win2D versions

### DIFF
--- a/build/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.nuspec
+++ b/build/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.nuspec
@@ -17,8 +17,8 @@
     <dependencies>
       <group targetFramework="net6.0-windows10.0.18362">
         <dependency id="Microsoft.Maui.Graphics" version="$version$" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Graphics.Win2D" version="1.0.1" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.WindowsAppSdk" version="1.0.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Graphics.Win2D" version="1.0.3.1" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.WindowsAppSdk" version="1.0.3" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
As the title says. The Win2D package removes the C++ dependency and that makes our Windows publishing story for .NET MAUI better.