### PR TITLE
Incorrect Windows service type name

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DImageLoadingService.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DImageLoadingService.cs
@@ -1,12 +1,18 @@
-﻿using System.IO;
+﻿using System;
+using System.ComponentModel;
+using System.IO;
 
 namespace Microsoft.Maui.Graphics.Win2D
 {
-	public class SkiaImageLoadingService : IImageLoadingService
+	public class W2DImageLoadingService : IImageLoadingService
 	{
 		public IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
 			return W2DImage.FromStream(stream, formatHint);
 		}
 	}
+
+	[Obsolete]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class SkiaImageLoadingService : W2DImageLoadingService { }
 }


### PR DESCRIPTION
### Description

I think this was a very unfortunate copy-paste error.

This PR renames the type, and then keeps the old type for compatibility. 