### PR TITLE
[maestro] manually adjusting versions for .NET 7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <_MauiTargetPlatformIstvOS Condition="'$(_MauiTargetPlatformIdentifier)' == 'tvos'">True</_MauiTargetPlatformIstvOS>
     <_MauiTargetPlatformIsWindows Condition="$(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWindows>
 
-    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows') or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <_MauiTargetPlatformIstvOS Condition="'$(_MauiTargetPlatformIdentifier)' == 'tvos'">True</_MauiTargetPlatformIstvOS>
     <_MauiTargetPlatformIsWindows Condition="$(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWindows>
 
-    <IncludeWindowsTargetFrameworks Condition="($([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full') or ('$(Packing)' == 'true')">true</IncludeWindowsTargetFrameworks>
+    <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows') or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="eng\Versions.props" />
     <PropertyGroup>
-    <_MauiDotNetVersion Condition="'$(_MauiDotNetVersion)' == ''">6.0</_MauiDotNetVersion>
+    <_MauiDotNetVersion Condition="'$(_MauiDotNetVersion)' == ''">7.0</_MauiDotNetVersion>
     <_MauiDotNetTfm Condition="'$(_MauiDotNetTfm)' == ''">net$(_MauiDotNetVersion)</_MauiDotNetTfm>
     <_MauiTargetPlatformIdentifier>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</_MauiTargetPlatformIdentifier>
     <_MauiNoTargetPlatform Condition="'$(_MauiTargetPlatformIdentifier)' == ''">True</_MauiNoTargetPlatform>
@@ -13,6 +13,10 @@
     <_MauiTargetPlatformIsWindows Condition="$(_MauiTargetPlatformIdentifier.Contains('windows')) == 'True'">True</_MauiTargetPlatformIsWindows>
 
     <IncludeWindowsTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(Packing)' == 'true'">true</IncludeWindowsTargetFrameworks>
+    <IncludeTizenTargetFrameworks>false</IncludeTizenTargetFrameworks>
+    <!-- <IncludeTizenTargetFrameworks Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true' or
+             Exists('$(DOTNET_ROOT)\sdk-manifests\$(DotNetVersionBand)\samsung.net.sdk.tizen\WorkloadManifest.json') or
+             Exists('$(ProgramFiles)\dotnet\sdk-manifests\$(DotNetVersionBand)\samsung.net.sdk.tizen\WorkloadManifest.json')">true</IncludeTizenTargetFrameworks> -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <DotNetToolPath>$(DotNetDirectory)dotnet</DotNetToolPath>
     <DotNetPacksDirectory>$(DotNetDirectory)packs/</DotNetPacksDirectory>
     <DotNetLibraryPacksDirectory>$(DotNetDirectory)library-packs/</DotNetLibraryPacksDirectory>
-    <DotNetSdkManifestsDirectory>$(DotNetDirectory)sdk-manifests/$(DotNetVersionBand)/</DotNetSdkManifestsDirectory>
+    <DotNetSdkManifestsDirectory>$(DotNetDirectory)sdk-manifests/$(DotNetSdkManifestsFolder)/</DotNetSdkManifestsDirectory>
     <DotNetTemplatePacksDirectory>$(DotNetDirectory)template-packs/</DotNetTemplatePacksDirectory>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-a21b9a2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-a21b9a2d/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
     <!--  End: Package sources from dotnet-windowsdesktop -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,6 +147,8 @@ stages:
 
             - pwsh: |
                 $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet/')
+                $env:DOTNET_INSTALL_DIR=$env:DOTNET_ROOT
+                $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_ROOT
                 $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
                 Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
                 Write-Host "PATH: $env:PATH"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ stages:
             - pwsh: dotnet tool restore
               displayName: install dotnet tools
             
-            - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration.name }}" --verbosity=diagnostic
+            - pwsh: ./build.ps1 --target=dotnet --configuration="${{ BuildConfiguration.name }}" --verbosity=diagnostic
               displayName: 'install .NET and workloads'
               retryCountOnTaskFailure: 3
               env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                & ./bin/dotnet/dotnet ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
+                & ./bin/dotnet/dotnet build ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
               displayName: build net6 solutions
 
             - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,11 +146,7 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' ./bin/dotnet/)
-                $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
-                Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
-                Write-Host "PATH: $env:PATH"
-                & $env:MSBUILD_EXE /r /m ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
+                & ./bin/dotnet/dotnet build ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
               displayName: build net6 solutions
 
             - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                & $env:MSBUILD_EXE /r /m ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
+                & ./bin/dotnet/dotnet ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
               displayName: build net6 solutions
 
             - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,23 +107,9 @@ stages:
 
             - pwsh: dotnet tool restore
               displayName: install dotnet tools
-          
-            - pwsh: |
-                [xml] $fileXml = Get-Content "eng\Versions.props"
-                $DotNetVersion = $fileXml.SelectSingleNode("Project/PropertyGroup/MicrosoftDotnetSdkInternalPackageVersion").InnerText
-                $DotNetVersionBand = $fileXml.SelectSingleNode("Project/PropertyGroup/DotNetVersionBand").InnerText
-                echo "Installing .NET $DotNetVersion"
-                Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-                & .\dotnet-install.ps1 -Version $DotNetVersion -InstallDir "$env:DOTNET_ROOT" -Verbose
-                echo "Removing signing"
-                & "${env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\signtool.exe" remove /s "$env:DOTNET_ROOT\sdk\$DotNetVersionBand\dotnet.dll"
-                echo "Listing installed SDKs"
-                & dotnet --list-sdks
-              displayName: install .NET
-              errorActionPreference: stop
             
-            - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration.name }}" --verbosity=diagnostic --installdotnet=false
-              displayName: 'install .NET workloads'
+            - pwsh: ./build.ps1 --target=dotnet-local-workloads --configuration="${{ BuildConfiguration.name }}" --verbosity=diagnostic
+              displayName: 'install .NET and workloads'
               retryCountOnTaskFailure: 3
               env:
                 DOTNET_TOKEN: $(dotnetbuilds-internal-container-read-token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ variables:
   DotNet.Cli.Telemetry.OptOut: true
   provisionator.path: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
+  provisionator.android: '$(System.DefaultWorkingDirectory)/eng/provisioning/android.csx'
   provisionator.extraArguments: '--v'
   signingCondition: or(eq(variables['Sign'], 'true'),
                        or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,6 +135,7 @@ stages:
                 Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
                 .\workload-install.ps1 -DotnetTargetVersionBand $DotNetVersionBand
               displayName: install tizen
+              condition: false
 
             - pwsh: |
                 $uri = 'https://go.microsoft.com/fwlink/?linkid=2083338'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,11 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                & ./bin/dotnet/dotnet build ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
+                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' ./bin/dotnet/)
+                $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
+                Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
+                Write-Host "PATH: $env:PATH"
+                & $env:MSBUILD_EXE /r /m ./Microsoft.Maui.Graphics-net6.sln /p:Configuration=${{ BuildConfiguration.name }} /bl:$(Build.ArtifactStagingDirectory)/${{ BuildConfiguration.name }}-net6.binlog
               displayName: build net6 solutions
 
             - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet/')
+                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' ./bin/dotnet/)
                 $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
                 Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
                 Write-Host "PATH: $env:PATH"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ trigger:
   branches:
     include:
     - main
+    - net7.0
     - release/*
     - darc-*
   tags:
@@ -49,6 +50,7 @@ pr:
   branches:
     include:
     - main
+    - net7.0
     - release/*
   paths:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ stages:
               displayName: build classic solutions
 
             - pwsh: |
-                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' ./bin/dotnet/)
+                $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet/')
                 $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
                 Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
                 Write-Host "PATH: $env:PATH"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ variables:
   DotNet.Cli.Telemetry.OptOut: true
   provisionator.path: '$(System.DefaultWorkingDirectory)/eng/provisioning/provisioning.csx'
   provisionator.vs: '$(System.DefaultWorkingDirectory)/eng/provisioning/vs.csx'
-  provisionator.android: '$(System.DefaultWorkingDirectory)/eng/provisioning/android.csx'
   provisionator.extraArguments: '--v'
   signingCondition: or(eq(variables['Sign'], 'true'),
                        or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,8 +147,6 @@ stages:
 
             - pwsh: |
                 $env:DOTNET_ROOT=(Join-Path '$(System.DefaultWorkingDirectory)' 'bin/dotnet/')
-                $env:DOTNET_INSTALL_DIR=$env:DOTNET_ROOT
-                $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_ROOT
                 $env:PATH=($env:DOTNET_ROOT + [IO.Path]::PathSeparator + $env:PATH)
                 Write-Host "DOTNET_ROOT: $env:DOTNET_ROOT"
                 Write-Host "PATH: $env:PATH"

--- a/build.cake
+++ b/build.cake
@@ -47,8 +47,6 @@ var dotnetInstallDirectory = EnvironmentVariable("DOTNET_ROOT");
 var localDotnet = GetBuildVariable("workloads",  (target == "VS-WINUI") ? "global" : "local") == "local";
 var vsVersion = GetBuildVariable("VS", "");
 
-var installDotNet = GetBuildVariable("installdotnet", "true");;
-
 DirectoryPath artifactStagingDirectory = MakeAbsolute(Directory(EnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY", "artifacts")));
 DirectoryPath logDirectory = MakeAbsolute(Directory(EnvironmentVariable("LogDirectory", $"{artifactStagingDirectory}/logs")));
 DirectoryPath testResultsDirectory = MakeAbsolute(Directory(EnvironmentVariable("TestResultsDirectory", $"{artifactStagingDirectory}/test-results")));

--- a/build/DotNet/DotNet.csproj
+++ b/build/DotNet/DotNet.csproj
@@ -109,11 +109,13 @@
 
   <ItemGroup>
     <!-- These are past workload names -->
-    <_PacksToRemove Include="Microsoft.NET.Workload.Android" />
-    <_PacksToRemove Include="Microsoft.NET.Workload.MacCatalyst" />
-    <_PacksToRemove Include="Microsoft.NET.Workload.iOS" />
-    <_PacksToRemove Include="Microsoft.NET.Workload.tvOS" />
-    <_PacksToRemove Include="Microsoft.NET.Workload.macOS" />
+    <_PacksToRemove Include="microsoft.net.sdk.android" />
+    <_PacksToRemove Include="microsoft.net.sdk.maccatalyst" />
+    <_PacksToRemove Include="microsoft.net.sdk.ios" />
+    <_PacksToRemove Include="microsoft.net.sdk.tvos" />
+    <_PacksToRemove Include="microsoft.net.sdk.macos" />
+    <_PacksToRemove Include="microsoft.net.workload.emscripten" />
+    <_PacksToRemove Include="microsoft.net.workload.mono.toolchain" />
     <!-- Ids for 'dotnet workload install' -->
     <_WorkloadIds Include="android" />
     <_WorkloadIds Include="maccatalyst" />
@@ -128,7 +130,11 @@
     <PropertyGroup>
       <_WorkloadManifestDir>$(DotNetTempDirectory)workload/</_WorkloadManifestDir>
     </PropertyGroup>
-    <RemoveDir Directories="$(_WorkloadManifestDir);@(_PacksToRemove->'$(DotNetSdkManifestsDirectory)%(Identity)')" />
+    <ItemGroup>
+      <_WorkloadDirectoriesToRemove Include="$(DotNetDirectory)sdk-manifests/$(DotNetVersionBand)" />
+      <_WorkloadDirectoriesToRemove Include="@(_PacksToRemove->'$(DotNetDirectory)sdk-manifests/$(DotNetSdkManifestsFolder)/%(Identity)')" />
+    </ItemGroup>
+    <RemoveDir Directories="$(_WorkloadManifestDir);@(_WorkloadDirectoriesToRemove)" />
     <MakeDir Directories="$(_WorkloadManifestDir)" />
     <Exec
         Command="&quot;$(DotNetToolPath)&quot; restore &quot;$(MSBuildThisFileDirectory)Dependencies/Workloads.csproj&quot; -bl:$(PackageOutputPath)/DotNetWorkloads.binlog"

--- a/build/DotNet/DotNet.csproj
+++ b/build/DotNet/DotNet.csproj
@@ -65,7 +65,7 @@
     <CopyWorkloadFiles
         Name="microsoft.net.sdk.maui"
         Files="@(_WorkloadFiles)"
-        WorkloadDirectory="$(MSBuildExtensionsPath)../../sdk-manifests/$(DotNetVersionBand)"
+        WorkloadDirectory="$(MSBuildExtensionsPath)../../sdk-manifests/$(DotNetSdkManifestsFolder)"
     />
     <RemoveDir Directories="$(_InstallTempDirectory)" />
 

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -30,12 +30,12 @@
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
       </group>
-      <group targetFramework="net6.0-windows10.0.18362">
+      <group targetFramework="net7.0-windows10.0.18362">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views.WinUI" version="2.88.0"/>
       </group>
-      <group targetFramework="net6.0-tizen6.5">
+      <!-- <group targetFramework="net7.0-tizen6.5">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
@@ -44,7 +44,7 @@
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
-      </group>
+      </group> -->
       <group targetFramework="xamarin.ios10">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
@@ -82,10 +82,10 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <!-- <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb"/> -->
 
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb"/>
@@ -93,7 +93,7 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/monoandroid12.0/Microsoft.Maui.Graphics.Skia.pdb" target="lib/monoandroid12.0/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.dll" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <!-- <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.dll" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.Skia.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.Skia.pdb"/> -->
   </files>
 </package>

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -15,7 +15,7 @@
     <license type="expression">MIT</license>
     <language>C#</language>
     <dependencies>
-      <group targetFramework="net6.0-android30.0">
+      <group targetFramework="net7.0-android32.0">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
@@ -78,8 +78,8 @@
 
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-android/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-android30.0/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-android/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-android30.0/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -20,12 +20,12 @@
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
       </group>
-      <group targetFramework="net6.0-ios13.6">
+      <group targetFramework="net7.0-ios13.6">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
       </group>
-      <group targetFramework="net6.0-maccatalyst13.5">
+      <group targetFramework="net7.0-maccatalyst13.5">
         <dependency id="Microsoft.Maui.Graphics" version="$version$"/>
         <dependency id="SkiaSharp" version="2.88.0"/>
         <dependency id="SkiaSharp.Views" version="2.88.0"/>
@@ -76,12 +76,12 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/netstandard2.1/Microsoft.Maui.Graphics.Skia.dll" target="lib/netstandard2.1/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/netstandard2.1/Microsoft.Maui.Graphics.Skia.pdb" target="lib/netstandard2.1/Microsoft.Maui.Graphics.Skia.pdb"/>
 
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-ios/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-ios13.6/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-ios/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-ios13.6/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.Skia.dll" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll"/>

--- a/build/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.nuspec
+++ b/build/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.nuspec
@@ -15,7 +15,7 @@
     <license type="expression">MIT</license>
     <language>C#</language>
     <dependencies>
-      <group targetFramework="net6.0-windows10.0.18362">
+      <group targetFramework="net7.0-windows10.0.18362">
         <dependency id="Microsoft.Maui.Graphics" version="$version$" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Graphics.Win2D" version="1.0.3.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.WindowsAppSdk" version="1.0.3" exclude="Build,Analyzers" />
@@ -23,7 +23,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.dll" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.pdb" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop.pdb"/>
   </files>
 </package>

--- a/build/Microsoft.Maui.Graphics.nuspec
+++ b/build/Microsoft.Maui.Graphics.nuspec
@@ -21,12 +21,12 @@
       </group>
       <group targetFramework="net7.0-maccatalyst13.5">
       </group>
-      <group targetFramework="net6.0-windows10.0.18362">
+      <group targetFramework="net7.0-windows10.0.18362">
       </group>
-      <group targetFramework="net6.0-tizen6.5">
+      <!-- <group targetFramework="net7.0-tizen6.5">
       </group>
       <group targetFramework="tizen40">
-      </group>
+      </group> -->
       <group targetFramework="xamarin.ios10">
       </group>
       <group targetFramework="monoandroid12.0">
@@ -60,11 +60,11 @@
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.dll" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb"/>
+    <!-- <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-tizen6.5/Microsoft.Maui.Graphics.dll" target="lib/net7.0-tizen6.5/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-tizen6.5/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-tizen6.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.dll" target="lib/tizen40/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.pdb"/> -->
   </files>
 </package>

--- a/build/Microsoft.Maui.Graphics.nuspec
+++ b/build/Microsoft.Maui.Graphics.nuspec
@@ -15,7 +15,7 @@
     <license type="expression">MIT</license>
     <language>C#</language>
     <dependencies>
-      <group targetFramework="net6.0-android30.0">
+      <group targetFramework="net7.0-android32.0">
       </group>
       <group targetFramework="net6.0-ios13.6">
       </group>
@@ -56,8 +56,8 @@
 
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.dll" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-android/Microsoft.Maui.Graphics.dll" target="lib/net6.0-android30.0/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-android/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-android30.0/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.dll" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.dll" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>

--- a/build/Microsoft.Maui.Graphics.nuspec
+++ b/build/Microsoft.Maui.Graphics.nuspec
@@ -17,9 +17,9 @@
     <dependencies>
       <group targetFramework="net7.0-android32.0">
       </group>
-      <group targetFramework="net6.0-ios13.6">
+      <group targetFramework="net7.0-ios13.6">
       </group>
-      <group targetFramework="net6.0-maccatalyst13.5">
+      <group targetFramework="net7.0-maccatalyst13.5">
       </group>
       <group targetFramework="net6.0-windows10.0.18362">
       </group>
@@ -54,12 +54,12 @@
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.dll" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/xamarin.mac20/Microsoft.Maui.Graphics.pdb" target="lib/xamarin.mac20/Microsoft.Maui.Graphics.pdb"/>
 
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.dll" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-ios/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-ios13.6/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-ios/Microsoft.Maui.Graphics.dll" target="lib/net7.0-ios13.6/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-ios/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-ios13.6/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.dll" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-android/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-android32.0/Microsoft.Maui.Graphics.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.dll" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.dll" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net7.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net7.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll"/>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="6.0.301-rtm.22254.17" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-preview.5.22263.22" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>3fed194c0b277b0ac0986f92401a50dd6c34f43d</Sha>
+      <Sha>2071f2cdca14396b68b38d719f291e3767f70d46</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.5" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.5.22258.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>a21b9a2dd4c31cf5bd37626562b7612faf21cee6</Sha>
+      <Sha>3e5517beb897faf4592d23f036446561da1e5c23</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="32.0.301">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="33.0.0-preview.4.6">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>4c460a89cb070ee8dfd731842f36bc3dc68dc75c</Sha>
+      <Sha>9fd37e3dfb72fef83c8ab157577102ce9acccf44</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.303">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>ce10c913a2921673b0caedcd268778b46d52c392</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.4.22215.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>52e9452f82e26f9fcae791e84c082ae22f1ef66f</Sha>
+      <Sha>f41e658e85769eef222f5f7571038edbd2d1d9d8</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>9fd37e3dfb72fef83c8ab157577102ce9acccf44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.303">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.173-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ce10c913a2921673b0caedcd268778b46d52c392</Sha>
+      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.303">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.173-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ce10c913a2921673b0caedcd268778b46d52c392</Sha>
+      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.303">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.173-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ce10c913a2921673b0caedcd268778b46d52c392</Sha>
+      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.303">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.173-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>ce10c913a2921673b0caedcd268778b46d52c392</Sha>
+      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.4.22215.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>9fd37e3dfb72fef83c8ab157577102ce9acccf44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.676-ci.net7-0">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.703-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
+      <Sha>1fe614df3dc19faa69ae16530f355a91f9c97987</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.676-ci.net7-0">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.703-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
+      <Sha>1fe614df3dc19faa69ae16530f355a91f9c97987</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.676-ci.net7-0">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.703-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
+      <Sha>1fe614df3dc19faa69ae16530f355a91f9c97987</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.676-ci.net7-0">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.703-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
+      <Sha>1fe614df3dc19faa69ae16530f355a91f9c97987</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.4.22215.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-preview.5.22263.22" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="7.0.100-preview.6.22276.1" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>2071f2cdca14396b68b38d719f291e3767f70d46</Sha>
+      <Sha>1a6c2ec5276c14fb4bb26f94baad970bf08206b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.5.22258.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.5.22272.3" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3e5517beb897faf4592d23f036446561da1e5c23</Sha>
+      <Sha>0864cc5539e0ddd109b443b0bee804878cd7ba76</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="33.0.0-preview.4.6">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="33.0.0-preview.4.25">
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
-      <Sha>9fd37e3dfb72fef83c8ab157577102ce9acccf44</Sha>
+      <Sha>f2276d43f1caa0d68dbb139157468f66e472efbf</Sha>
     </Dependency>
     <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.703-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
@@ -28,9 +28,9 @@
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
       <Sha>1fe614df3dc19faa69ae16530f355a91f9c97987</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.4.22215.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.5.22252.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>f41e658e85769eef222f5f7571038edbd2d1d9d8</Sha>
+      <Sha>aeb9a3591b687c3f141e43b330604b34da738149</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,21 +12,21 @@
       <Uri>https://github.com/xamarin/xamarin-android</Uri>
       <Sha>9fd37e3dfb72fef83c8ab157577102ce9acccf44</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.173-ci.net7-0">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk" Version="15.4.676-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
+      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.173-ci.net7-0">
+    <Dependency Name="Microsoft.iOS.Sdk" Version="15.4.676-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
+      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.173-ci.net7-0">
+    <Dependency Name="Microsoft.tvOS.Sdk" Version="15.4.676-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
+      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.173-ci.net7-0">
+    <Dependency Name="Microsoft.macOS.Sdk" Version="12.3.676-ci.net7-0">
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
-      <Sha>06c97d2e01f66efc14f8fb79b43778b631b3ab33</Sha>
+      <Sha>912b4022dc8b8c5e8383b6ed8f7c826770b5ed56</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-7.0.100" Version="7.0.0-preview.4.22215.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,6 @@
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)-preview.4</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)-preview.5</DotNetMaciOSManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,14 +2,14 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.5.22263.22</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.6.22276.1</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.5.22258.4</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.5.22272.3</MicrosoftNETCoreAppRefPackageVersion>
     <!-- dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-preview.4.22215.1</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-preview.5.22252.1</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.25</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftiOSSdkPackageVersion>15.4.703-ci.net7-0</MicrosoftiOSSdkPackageVersion>
     <MicrosoftMacCatalystSdkPackageVersion>15.4.703-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,6 +23,6 @@
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>6.0.300</DotNetMaciOSManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,10 +11,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftiOSSdkPackageVersion>15.4.173-ci.net7-0</MicrosoftiOSSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.4.173-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>12.3.173-ci.net7-0</MicrosoftmacOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.4.173-ci.net7-0</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>15.4.676-ci.net7-0</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.4.676-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>12.3.676-ci.net7-0</MicrosoftmacOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.4.676-ci.net7-0</MicrosofttvOSSdkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22171.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22171.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <DotNetVersionBand Condition=" '$(DotNetVersionBand)' == '' ">6.0.300</DotNetVersionBand>
+    <DotNetVersionBand Condition=" '$(DotNetVersionBand)' == '' ">7.0.100</DotNetVersionBand>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,14 +2,14 @@
   <!--Package versions-->
   <PropertyGroup>
     <!-- dotnet/installer -->
-    <MicrosoftDotnetSdkInternalPackageVersion>6.0.301-rtm.22254.17</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>7.0.100-preview.5.22263.22</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.5</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.5.22258.4</MicrosoftNETCoreAppRefPackageVersion>
     <!-- dotnet/emsdk -->
-    <MicrosoftNETWorkloadEmscriptenManifest60300PackageVersion>6.0.4</MicrosoftNETWorkloadEmscriptenManifest60300PackageVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-preview.4.22215.1</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest60300PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- xamarin/xamarin-android -->
-    <MicrosoftAndroidSdkWindowsPackageVersion>32.0.301</MicrosoftAndroidSdkWindowsPackageVersion>
+    <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
     <MicrosoftiOSSdkPackageVersion>15.4.303</MicrosoftiOSSdkPackageVersion>
     <MicrosoftMacCatalystSdkPackageVersion>15.4.303</MicrosoftMacCatalystSdkPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,10 +11,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftiOSSdkPackageVersion>15.4.303</MicrosoftiOSSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.4.303</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>12.3.303</MicrosoftmacOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.4.303</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>15.4.173-ci.net7-0</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.4.173-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>12.3.173-ci.net7-0</MicrosoftmacOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.4.173-ci.net7-0</MicrosofttvOSSdkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22171.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -24,6 +24,6 @@
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>6.0.300</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>
-    <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)-preview.5</DotNetMaciOSManifestVersionBand>
+    <DotNetAndroidManifestVersionBand>$(DotNetSdkManifestsFolder)</DotNetAndroidManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>$(DotNetSdkManifestsFolder)</DotNetMaciOSManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,6 @@
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>
     <DotNetAndroidManifestVersionBand>$(DotNetVersionBand)</DotNetAndroidManifestVersionBand>
-    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)</DotNetMaciOSManifestVersionBand>
+    <DotNetMaciOSManifestVersionBand>$(DotNetVersionBand)-preview.4</DotNetMaciOSManifestVersionBand>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,10 +11,10 @@
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->
-    <MicrosoftiOSSdkPackageVersion>15.4.676-ci.net7-0</MicrosoftiOSSdkPackageVersion>
-    <MicrosoftMacCatalystSdkPackageVersion>15.4.676-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>
-    <MicrosoftmacOSSdkPackageVersion>12.3.676-ci.net7-0</MicrosoftmacOSSdkPackageVersion>
-    <MicrosofttvOSSdkPackageVersion>15.4.676-ci.net7-0</MicrosofttvOSSdkPackageVersion>
+    <MicrosoftiOSSdkPackageVersion>15.4.703-ci.net7-0</MicrosoftiOSSdkPackageVersion>
+    <MicrosoftMacCatalystSdkPackageVersion>15.4.703-ci.net7-0</MicrosoftMacCatalystSdkPackageVersion>
+    <MicrosoftmacOSSdkPackageVersion>12.3.703-ci.net7-0</MicrosoftmacOSSdkPackageVersion>
+    <MicrosofttvOSSdkPackageVersion>15.4.703-ci.net7-0</MicrosofttvOSSdkPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22171.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DotNetVersionBand Condition=" '$(DotNetVersionBand)' == '' ">7.0.100</DotNetVersionBand>
+    <DotNetSdkManifestsFolder>$(DotNetVersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-preview.\d+`))</DotNetSdkManifestsFolder>
     <DotNetMauiManifestVersionBand>$(DotNetVersionBand)</DotNetMauiManifestVersionBand>
     <DotNetMonoManifestVersionBand>$(DotNetVersionBand)</DotNetMonoManifestVersionBand>
     <DotNetEmscriptenManifestVersionBand>$(DotNetVersionBand)</DotNetEmscriptenManifestVersionBand>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MicrosoftNETCoreAppRefPackageVersion>7.0.0-preview.5.22258.4</MicrosoftNETCoreAppRefPackageVersion>
     <!-- dotnet/emsdk -->
     <MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>7.0.0-preview.4.22215.1</MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion>
-    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest60300PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
+    <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenManifest70100PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <!-- xamarin/xamarin-android -->
     <MicrosoftAndroidSdkWindowsPackageVersion>33.0.0-preview.4.6</MicrosoftAndroidSdkWindowsPackageVersion>
     <!-- xamarin/xamarin-macios -->

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -5,7 +5,7 @@ var dotnetPath = $"./bin/dotnet/dotnet{ext}";
 
 // Tasks for CI
 
-Task("dotnet-local-workloads")
+Task("dotnet")
     .Does(() =>
     {
         DotNetCoreBuild("./build/DotNet/DotNet.csproj", new DotNetCoreBuildSettings

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -5,33 +5,14 @@ var dotnetPath = $"./bin/dotnet/dotnet{ext}";
 
 // Tasks for CI
 
-Task("dotnet")
-    .Description("Provisions .NET 6 into bin/dotnet based on eng/Versions.props")
-    .Does(() =>
-    {
-        if (!localDotnet) 
-            return;
-
-        DotNetCoreBuild("./src/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
-        {
-            MSBuildSettings = new DotNetCoreMSBuildSettings()
-                .EnableBinaryLogger($"{logDirectory}/dotnet-{configuration}.binlog")
-                .SetConfiguration(configuration),
-        });
-    });
-
 Task("dotnet-local-workloads")
     .Does(() =>
     {
-        if (!localDotnet) 
-            return;
-        
         DotNetCoreBuild("./build/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
         {
             MSBuildSettings = new DotNetCoreMSBuildSettings()
-                .EnableBinaryLogger($"{logDirectory}/dotnet-workloads-{configuration}.binlog")
+                .EnableBinaryLogger($"{logDirectory}/dotnet-{configuration}.binlog")
                 .SetConfiguration(configuration)
-                .WithProperty("InstallDotNet", installDotNet)
         });
     });
 

--- a/eng/cake/dotnet.cake
+++ b/eng/cake/dotnet.cake
@@ -26,27 +26,13 @@ Task("dotnet-local-workloads")
         if (!localDotnet) 
             return;
         
-        if(!string.IsNullOrEmpty(dotnetInstallDirectory))
+        DotNetCoreBuild("./build/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
         {
-            DotNetCoreBuild("./build/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
-            {
-                MSBuildSettings = new DotNetCoreMSBuildSettings()
-                    .EnableBinaryLogger($"{logDirectory}/dotnet-workloads-{configuration}.binlog")
-                    .SetConfiguration(configuration)
-                    .WithProperty("InstallDotNet", installDotNet)
-                    .WithProperty("DotNetDirectory", dotnetInstallDirectory+"/")
-            });
-        }
-        else
-        {
-            DotNetCoreBuild("./build/DotNet/DotNet.csproj", new DotNetCoreBuildSettings
-            {
-                MSBuildSettings = new DotNetCoreMSBuildSettings()
-                    .EnableBinaryLogger($"{logDirectory}/dotnet-workloads-{configuration}.binlog")
-                    .SetConfiguration(configuration)
-                    .WithProperty("InstallDotNet", installDotNet)
-            });
-        }
+            MSBuildSettings = new DotNetCoreMSBuildSettings()
+                .EnableBinaryLogger($"{logDirectory}/dotnet-workloads-{configuration}.binlog")
+                .SetConfiguration(configuration)
+                .WithProperty("InstallDotNet", installDotNet)
+        });
     });
 
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -74,14 +74,15 @@ steps:
         }
       displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provision Android SDK'
+      inputs:
+        provisioning_script: $(provisionator.android)
+        provisioning_extra_args: '-v -v -v -v'
+    - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
       condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provision Android SDK'
-      inputs:
-        provisioning_script: $(provisionator.android)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -83,7 +83,11 @@ steps:
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"
       displayName: 'Setup MSBuild Paths'
       condition: eq(variables['provisioningVS'], 'true')
-
+    - pwsh: |
+        Write-Host $env:ANDROID_HOME
+        Write-Host $env:ANDROID_SDK_HOME
+        'y' | & "${env:ProgramFiles(x86)}\Android\android-sdk\tools\bin\sdkmanager" "platforms;android-32"
+      displayName: Install Android API 32
 
   # # Prepare Both
   # - pwsh: ./build.ps1 --target provision

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -84,8 +84,7 @@ steps:
       displayName: 'Setup MSBuild Paths'
       condition: eq(variables['provisioningVS'], 'true')
     - pwsh: |
-        Write-Host $env:ANDROID_HOME
-        Write-Host $env:ANDROID_SDK_HOME
+        ls -r -n "${env:ProgramFiles(x86)}\Android\android-sdk\"
         'y' | & "${env:ProgramFiles(x86)}\Android\android-sdk\tools\bin\sdkmanager" "platforms;android-32"
       displayName: Install Android API 32
 

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -78,10 +78,6 @@ steps:
       condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provision Android SDK'
-      inputs:
-        provisioning_script: $(provisionator.android)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -78,6 +78,10 @@ steps:
       condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provision Android SDK'
+      inputs:
+        provisioning_script: $(provisionator.android)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -84,8 +84,7 @@ steps:
       displayName: 'Setup MSBuild Paths'
       condition: eq(variables['provisioningVS'], 'true')
     - pwsh: |
-        ls -r -n "${env:ProgramFiles(x86)}\Android\android-sdk\"
-        'y' | & "${env:ProgramFiles(x86)}\Android\android-sdk\tools\bin\sdkmanager" "platforms;android-32"
+        'y' | & "${env:ProgramFiles(x86)}\Android\android-sdk\cmdline-tools\5.0\bin\sdkmanager" "platforms;android-32"
       displayName: Install Android API 32
 
   # # Prepare Both

--- a/eng/pipelines/common/provision.yml
+++ b/eng/pipelines/common/provision.yml
@@ -74,15 +74,14 @@ steps:
         }
       displayName: 'Install PowerShell Core'
     - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provision Android SDK'
-      inputs:
-        provisioning_script: $(provisionator.android)
-        provisioning_extra_args: '-v -v -v -v'
-    - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provision Visual Studio'
       condition: eq(variables['provisioningVS'], 'true')
       inputs:
         provisioning_script: $(provisionator.vs)
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provision Android SDK'
+      inputs:
+        provisioning_script: $(provisionator.android)
     - pwsh: |
         $msbuild = "$env:ProgramFiles/Microsoft Visual Studio/2022/Preview/MSBuild/Current/Bin/MSBuild.exe"
         echo "##vso[task.setvariable variable=MSBUILD_EXE]$msbuild"

--- a/eng/provisioning/android.csx
+++ b/eng/provisioning/android.csx
@@ -1,0 +1,2 @@
+// API 32 required for net7.0-android
+AndroidSdk().ApiLevel((AndroidApiLevel)32);

--- a/eng/provisioning/android.csx
+++ b/eng/provisioning/android.csx
@@ -1,2 +1,0 @@
-// API 32 required for net7.0-android
-AndroidSdk().ApiLevel((AndroidApiLevel)32);

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -105,6 +105,7 @@ if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS))
 		.ApiLevel((AndroidApiLevel)29)
 		.ApiLevel((AndroidApiLevel)30)
 		.ApiLevel((AndroidApiLevel)31)
+		.ApiLevel((AndroidApiLevel)32)
 		.SdkManagerPackage ("build-tools;29.0.3");
 }
 else{

--- a/eng/provisioning/provisioning.csx
+++ b/eng/provisioning/provisioning.csx
@@ -105,7 +105,6 @@ if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS))
 		.ApiLevel((AndroidApiLevel)29)
 		.ApiLevel((AndroidApiLevel)30)
 		.ApiLevel((AndroidApiLevel)31)
-		.ApiLevel((AndroidApiLevel)32)
 		.SdkManagerPackage ("build-tools;29.0.3");
 }
 else{

--- a/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
+++ b/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-android</TargetFramework>
+		<TargetFramework>$(_MauiDotNetVersion)-android</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Android</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
+++ b/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(_MauiDotNetVersion)-android</TargetFramework>
+		<TargetFramework>$(_MauiDotNetTfm)-android</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Android</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
+++ b/samples/GraphicsTester.Android/GraphicsTester.Android-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-android</TargetFramework>
+		<TargetFramework>net7.0-android</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Android</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
+++ b/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(_MauiDotNetVersion)-macos</TargetFramework>
+		<TargetFramework>$(_MauiDotNetTfm)-macos</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Mac</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
+++ b/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-macos</TargetFramework>
+		<TargetFramework>net7.0-macos</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Mac</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-macos'">10.14</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-macos'">10.14</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
+++ b/samples/GraphicsTester.Mac/GraphicsTester.Mac-net6.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-macos</TargetFramework>
+		<TargetFramework>$(_MauiDotNetVersion)-macos</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.Mac</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-macos'">10.14</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
+++ b/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(_MauiDotNetVersion)-maccatalyst</TargetFramework>
+		<TargetFramework>$(_MauiDotNetTfm)-maccatalyst</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.MacCatalyst</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
+++ b/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-maccatalyst</TargetFramework>
+		<TargetFramework>net7.0-maccatalyst</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.MacCatalyst</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">14.2</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
+++ b/samples/GraphicsTester.MacCatalyst/GraphicsTester.MacCatalyst-net6.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-maccatalyst</TargetFramework>
+		<TargetFramework>$(_MauiDotNetVersion)-maccatalyst</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.MacCatalyst</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-maccatalyst'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
+++ b/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;$(_MauiDotNetVersion)</TargetFrameworks>
         <AssemblyName>GraphicsTester.Portable</AssemblyName>
         <RootNamespace>GraphicsTester</RootNamespace>
         <Version>2.0.0</Version>

--- a/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
+++ b/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;$(_MauiDotNetVersion)</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;$(_MauiDotNetTfm)</TargetFrameworks>
         <AssemblyName>GraphicsTester.Portable</AssemblyName>
         <RootNamespace>GraphicsTester</RootNamespace>
         <Version>2.0.0</Version>

--- a/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
+++ b/samples/GraphicsTester.Portable/GraphicsTester.Portable-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
         <AssemblyName>GraphicsTester.Portable</AssemblyName>
         <RootNamespace>GraphicsTester</RootNamespace>
         <Version>2.0.0</Version>

--- a/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
+++ b/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0-macos</TargetFramework>
+        <TargetFramework>$(_MauiDotNetVersion)-macos</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>GraphicsTester.Skia.Mac</RootNamespace>
         <LangVersion>10.0</LangVersion>
 
-        <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-macos'">10.14</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
 
     </PropertyGroup>
 

--- a/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
+++ b/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>$(_MauiDotNetVersion)-macos</TargetFramework>
+        <TargetFramework>$(_MauiDotNetTfm)-macos</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>GraphicsTester.Skia.Mac</RootNamespace>
         <LangVersion>10.0</LangVersion>

--- a/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
+++ b/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0-macos</TargetFramework>
+        <TargetFramework>net7.0-macos</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>GraphicsTester.Skia.Mac</RootNamespace>
         <LangVersion>10.0</LangVersion>
 
-        <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-macos'">10.14</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-macos'">10.14</SupportedOSPlatformVersion>
 
     </PropertyGroup>
 

--- a/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
+++ b/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-ios</TargetFramework>
+		<TargetFramework>net7.0-ios</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.iOS</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-ios'">14.2</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
+++ b/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-ios</TargetFramework>
+		<TargetFramework>$(_MauiDotNetVersion)-ios</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.iOS</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>10.0</LangVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net7.0-ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>14.2</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
+++ b/samples/GraphicsTester.iOS/GraphicsTester.iOS-net6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(_MauiDotNetVersion)-ios</TargetFramework>
+		<TargetFramework>$(_MauiDotNetTfm)-ios</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>GraphicsTester.iOS</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-macos;net7.0-android;net6.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-macos;net7.0-android;net6.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetVersion)-ios;$(_MauiDotNetVersion)-macos;$(_MauiDotNetVersion)-android;$(_MauiDotNetVersion)-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-windows10.0.18362</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetTfm)-ios;$(_MauiDotNetTfm)-macos;$(_MauiDotNetTfm)-android;$(_MauiDotNetTfm)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetTfm)-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetTfm)-tizen6.5</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
     <LangVersion>10.0</LangVersion>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
     <LangVersion>10.0</LangVersion>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetVersion)-ios;$(_MauiDotNetVersion)-macos;$(_MauiDotNetVersion)-android;$(_MauiDotNetVersion)-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-tizen6.5</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
     <LangVersion>10.0</LangVersion>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -2,10 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-macos;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
     <LangVersion>10.0</LangVersion>
+    <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.18362</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.18362</TargetFramework>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
@@ -9,6 +9,9 @@
     <LangVersion>10.0</LangVersion>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(_MauiDotNetVersion)-windows10.0.18362</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)-windows10.0.18362</TargetFramework>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows10.0.18362</TargetFramework>
+    <TargetFramework>$(_MauiDotNetVersion)-windows10.0.18362</TargetFramework>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <RootNamespace>Microsoft.Maui.Graphics.Win2D.WinUI.Desktop</RootNamespace>

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net7.0-android;net6.0-maccatalyst;net6.0-macos;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-android;net7.0-maccatalyst;net7.0-macos;net6.0-tizen6.5</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetVersion)-ios;$(_MauiDotNetVersion)-android;$(_MauiDotNetVersion)-maccatalyst;$(_MauiDotNetVersion)-macos</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-windows10.0.18362</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetTfm)-ios;$(_MauiDotNetTfm)-android;$(_MauiDotNetTfm)-maccatalyst;$(_MauiDotNetTfm)-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetTfm)-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetTfm)-tizen6.5</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-macos;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net7.0-android;net6.0-maccatalyst;net6.0-macos;net6.0-tizen6.5</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-android;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;$(_MauiDotNetVersion)-ios;$(_MauiDotNetVersion)-android;$(_MauiDotNetVersion)-maccatalyst;$(_MauiDotNetVersion)-macos</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeWindowsTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(_MauiDotNetVersion)-tizen6.5</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-android;net7.0-maccatalyst;net7.0-macos;net6.0-tizen6.5</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-android;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0-ios;net7.0-android;net7.0-maccatalyst;net7.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.18362</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
@@ -10,6 +10,9 @@
     <AssemblyName>Microsoft.Maui.Graphics</AssemblyName>
     <RootNamespace>Microsoft.Maui.Graphics</RootNamespace>
     <LangVersion>10.0</LangVersion>
+    <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Microsoft.Maui.Graphics</PackageId>

--- a/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
+++ b/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
+++ b/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(_MauiDotNetVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
+++ b/tests/Microsoft.Maui.Graphics.Benchmarks/Microsoft.Maui.Graphics.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(_MauiDotNetVersion)</TargetFramework>
+    <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We tried triggering subscriptions, such as:

    darc trigger-subscriptions --source-repo https://github.com/xamarin/xamarin-android --target-repo https://github.com/dotnet/Microsoft.Maui.Graphics --target-branch net7.0 --verbose

But then no PR opens?

So then I checked the build at:

https://maestro-prod.westus2.cloudapp.azure.com/2237/https:%2F%2Fgithub.com%2Fxamarin%2Fxamarin-android/latest/graph

Using the build id:

    darc update-dependencies --id 136370 --verbose

We get the error:

    fail: Microsoft.DotNet.Darc.Operations.Operation[0]
    Non-continuable HTTP 401 error encountered while making request
    System.Net.Http.HttpRequestException: Response status code does not indicate success: 401 (Unauthorized).
    at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
    at Microsoft.DotNet.DarcLib.HttpRequestManager.ExecuteAsync(Int32 retryCount) in /_/src/Microsoft.DotNet.Darc/src/DarcLib/Helpers/HttpRequestManager.cs:line 97
    fail: Microsoft.DotNet.Darc.Operations.Operation[0]
    Something failed while trying the fetch the dependencies of repo 'https://dev.azure.com/dnceng/internal/_git/dotnet-optimization'

Trial and error, I found removing this element in
`Version.Details.xml` solved it:

    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.300" Version="6.0.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">

I switched to `Microsoft.NET.Workload.Emscripten.Manifest-7.0.100`
that xamarin-android is using here:

https://github.com/xamarin/xamarin-android/blob/6568f901a5b1a3829d8d5a5254eddd62a1765b95/eng/Version.Details.xml#L15-L18

And then things worked! I think Maestro updates will start working
after this goes in.

I also updated the `CoherentParentDependency` on:

    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-preview.5.22258.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">

To match what xamarin-android has.