### PR TITLE
Rename W2DImage to PlatformImage

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/PlatformImage.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/PlatformImage.cs
@@ -7,18 +7,18 @@ using Windows.Storage.Streams;
 
 namespace Microsoft.Maui.Graphics.Win2D
 {
-	internal class W2DImage : IImage
+	public class PlatformImage : IImage
 	{
 		private readonly ICanvasResourceCreator _creator;
 		private CanvasBitmap _bitmap;
 
-		public W2DImage(ICanvasResourceCreator creator, CanvasBitmap bitmap)
+		public PlatformImage(ICanvasResourceCreator creator, CanvasBitmap bitmap)
 		{
 			_creator = creator;
 			_bitmap = bitmap;
 		}
 
-		public CanvasBitmap PlatformImage => _bitmap;
+		public CanvasBitmap Bitmap => _bitmap;
 
 		public void Dispose()
 		{
@@ -118,7 +118,7 @@ namespace Microsoft.Maui.Graphics.Win2D
 				throw new Exception("No resource creator has been registered globally or for this thread.");
 
 			var bitmap = AsyncPump.Run(async () => await CanvasBitmap.LoadAsync(creator, stream.AsRandomAccessStream()));
-			return new W2DImage(creator, bitmap);
+			return new PlatformImage(creator, bitmap);
 		}
 	}
 }

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DCanvas.cs
@@ -374,9 +374,9 @@ After:
 
 			if (paint is ImagePaint imagePaint)
 			{
-				if (imagePaint.Image is W2DImage image)
+				if (imagePaint.Image is PlatformImage platformImage)
 				{
-					var bitmapBrush = new CanvasImageBrush(_session, image.PlatformImage)
+					var bitmapBrush = new CanvasImageBrush(_session, platformImage.Bitmap)
 					{
 						ExtendX = CanvasEdgeBehavior.Wrap,
 						ExtendY = CanvasEdgeBehavior.Wrap
@@ -510,17 +510,17 @@ After:
 
 		public override void DrawImage(IImage image, float x, float y, float width, float height)
 		{
-			if (image is W2DImage platformImage)
+			if (image is PlatformImage platformImage)
 			{
 				SetRect(x, y, width, height);
 
-/* Unmerged change from project 'Microsoft.Maui.Graphics.Win2D.WinUI.Desktop'
-Before:
-				Draw(s => s.DrawImage(platformImage.PlatformImage, _rect, Rect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
-After:
-				Draw(s => s.DrawImage(platformImage.PlatformImage, _rect, global::Windows.Foundation.Rect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
-*/
-				Draw(s => s.DrawImage(platformImage.PlatformImage, _rect, WRect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
+				/* Unmerged change from project 'Microsoft.Maui.Graphics.Win2D.WinUI.Desktop'
+				Before:
+								Draw(s => s.DrawImage(platformImage.Bitmap, _rect, Rect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
+				After:
+								Draw(s => s.DrawImage(platformImage.Bitmap, _rect, global::Windows.Foundation.Rect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
+				*/
+				Draw(s => s.DrawImage(platformImage.Bitmap, _rect, WRect.Empty, CurrentState.Alpha, CanvasImageInterpolation.Linear));
 			}
 		}
 

--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DImageLoadingService.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DImageLoadingService.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Maui.Graphics.Win2D
 	{
 		public IImage FromStream(Stream stream, ImageFormat formatHint = ImageFormat.Png)
 		{
-			return W2DImage.FromStream(stream, formatHint);
+			return PlatformImage.FromStream(stream, formatHint);
 		}
 	}
 


### PR DESCRIPTION
With this changes we can avoid this issue:
![image](https://user-images.githubusercontent.com/6755973/176698917-e99423bc-686b-49e7-b724-ac0e41f6ed99.png)

@jonlipsky Why was the W2DImage an internal class?

Fixes #457
Fixes #402