### PR TITLE
Fix set the Font to Microsoft.Maui.Graphics.Skia

### DIFF
--- a/src/Microsoft.Maui.Graphics.Skia/SkiaCanvasState.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/SkiaCanvasState.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Maui.Graphics.Skia
 		{
 			set
 			{
-				if (_font != value && (_font != null && !_font.Equals(value)))
+				if (!ReferenceEquals(_font, value) && (_font is null || !_font.Equals(value)))
 				{
 					_font = value;
 					_typefaceInvalid = true;


### PR DESCRIPTION
When the `_font` is null that it will never set the value to the `_font` field.

It always return false when the `_font` is null:

```
_font != value && _font != null
```

This bug is a cause of https://github.com/dotnet/Microsoft.Maui.Graphics/issues/473 . We can not set any Font name to SkiaCanvas and the default Font do not support Chinese text.