### PR TITLE
Allow the extensibility for W2DGraphicsView

### DIFF
--- a/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DGraphicsView.cs
+++ b/src/Microsoft.Maui.Graphics.Win2D.WinUI.Desktop/W2DGraphicsView.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.Maui.Graphics.Win2D
 {
-	public sealed class W2DGraphicsView : UserControl
+	public class W2DGraphicsView : UserControl
 	{
 		private CanvasControl _canvasControl;
 		private readonly W2DCanvas _canvas;


### PR DESCRIPTION
Allow the extensibility for **W2DGraphicsView**. PlatformGraphicView in the rest of the platforms is not sealed.

Fixes https://github.com/dotnet/maui/issues/9460