### PR TITLE
[net6.0] Add NUI-based SkiaGraphicsView for Tizen

### DIFF
--- a/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Tizen.nui.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Tizen.nui.cs
@@ -1,0 +1,45 @@
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Skia;
+using SkiaSharp.Views.Tizen.NUI;
+using Tizen.NUI;
+using SKPaintSurfaceEventArgs = SkiaSharp.Views.Tizen.SKPaintSurfaceEventArgs;
+
+namespace Microsoft.Maui.Graphics.Skia.Views
+{
+	public class SkiaGraphicsView : SKCanvasView
+	{
+		private IDrawable _drawable;
+		private SkiaCanvas _canvas;
+		private ScalingCanvas _scalingCanvas;
+
+		public SkiaGraphicsView(IDrawable drawable = null) : base()
+		{
+			_canvas = new SkiaCanvas();
+			_scalingCanvas = new ScalingCanvas(_canvas);
+			Drawable = drawable;
+			PaintSurface += OnPaintSurface;
+			IgnorePixelScaling = true;
+		}
+
+		public IDrawable Drawable
+		{
+			get => _drawable;
+			set
+			{
+				_drawable = value;
+				Invalidate();
+			}
+		}
+
+		protected virtual void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+		{
+			if (_drawable == null) return;
+
+			var skiaCanvas = e.Surface.Canvas;
+			skiaCanvas.Clear();
+
+			_canvas.Canvas = skiaCanvas;
+			_drawable.Draw(_scalingCanvas, new RectF(0, 0, e.Info.Width , e.Info.Height));
+		}
+	}
+}

--- a/src/targets/MultiTargeting.targets
+++ b/src/targets/MultiTargeting.targets
@@ -65,7 +65,13 @@
     <Compile Remove="**\Win32\*.cs"/>
     <None Include="**\Win32\*.cs"/>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) == true Or '$(TargetPlatformIdentifier)' == 'tizen'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) == true">
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
+    <Compile Remove="**\*.Tizen.nui.cs" />
+    <None Include="**\*.Tizen.nui.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.Contains('-tizen'))">
+    <Compile Remove="**\*.Tizen.cs"/>
+    <None Include="**\*.Tizen.cs"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is to change the tizen backend implementation of SkiaGrpahicsView from EFL (legacy Tizen UI FW) to NUI (brand new Tizen .NET UI FW). Please refer to MAUI([#9620](https://github.com/dotnet/maui/pull/9620)) and SkiaSharp([#2225](https://github.com/mono/SkiaSharp/pull/2225)) fixes related to this together.

> Keep this PR as a draft until a new version of SkiaSharp packages is released. 