### PR TITLE
[Tizen] Add NUI-based SkiaGraphicsView for net6

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,7 +17,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
+    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -17,7 +17,8 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
+    <add key="skiasharp" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/SkiaSharp/nuget/v3/index.json" />
+    <add key="skiasharp-stable-sha-signed" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/skiasharp-stable-88c09609-signed/nuget/v3/index.json" />
     <add key="wasdk-internal" value="https://pkgs.dev.azure.com/microsoft/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>

--- a/build/Microsoft.Maui.Graphics.Skia.nuspec
+++ b/build/Microsoft.Maui.Graphics.Skia.nuspec
@@ -84,8 +84,8 @@
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.Skia.pdb"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.Skia.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll"/>
-    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.dll"/>
+    <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.Skia.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.Skia.pdb"/>
 
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.dll"/>
     <file src="src/Microsoft.Maui.Graphics.Skia/bin/$configuration$/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb" target="lib/xamarin.ios10/Microsoft.Maui.Graphics.Skia.pdb"/>

--- a/build/Microsoft.Maui.Graphics.nuspec
+++ b/build/Microsoft.Maui.Graphics.nuspec
@@ -62,8 +62,8 @@
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-maccatalyst/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-maccatalyst13.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-windows10.0.18362/Microsoft.Maui.Graphics.pdb"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll"/>
-    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen6.5/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.pdb"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.dll" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.dll"/>
+    <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/net6.0-tizen/Microsoft.Maui.Graphics.pdb" target="lib/net6.0-tizen6.5/Microsoft.Maui.Graphics.pdb"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.dll" target="lib/tizen40/Microsoft.Maui.Graphics.dll"/>
     <file src="src/Microsoft.Maui.Graphics/bin/$configuration$/tizen40/Microsoft.Maui.Graphics.pdb" target="lib/tizen40/Microsoft.Maui.Graphics.pdb"/>
   </files>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,8 @@
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22171.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <!-- SkiaSharp -->
+    <SkiaSharpVersion>2.88.2</SkiaSharpVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DotNetVersionBand Condition=" '$(DotNetVersionBand)' == '' ">6.0.400</DotNetVersionBand>

--- a/samples/GraphicsTester.Skia.Console/GraphicsTester.Skia.Console.csproj
+++ b/samples/GraphicsTester.Skia.Console/GraphicsTester.Skia.Console.csproj
@@ -11,7 +11,7 @@
         <ProjectReference Include="..\GraphicsTester.Portable\GraphicsTester.Portable.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="SkiaSharp" Version="2.88.0" />
+        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
 
 </Project>

--- a/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
+++ b/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac-net6.csproj
@@ -20,8 +20,8 @@
       <UseSGen>false</UseSGen>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="SkiaSharp" Version="2.88.0" />
-        <PackageReference Include="SkiaSharp.Views" Version="2.88.0" />
+        <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+        <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
+++ b/samples/GraphicsTester.Skia.Mac/GraphicsTester.Skia.Mac.csproj
@@ -113,10 +113,10 @@
       <Version>0.22.1</Version>
     </PackageReference>
     <PackageReference Include="SkiaSharp">
-      <Version>2.88.0</Version>
+      <Version>$(SkiaSharpVersion)</Version>
     </PackageReference>
     <PackageReference Include="SkiaSharp.Views">
-      <Version>2.88.0</Version>
+      <Version>$(SkiaSharpVersion)</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>

--- a/samples/GraphicsTester.Skia.Windows/GraphicsTester.Skia.Windows.csproj
+++ b/samples/GraphicsTester.Skia.Windows/GraphicsTester.Skia.Windows.csproj
@@ -65,9 +65,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.0">
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)">
     </PackageReference>
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.0">
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)">
     </PackageReference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Microsoft.Maui.Graphics.Skia.GtkSharp/Microsoft.Maui.Graphics.Skia.GtkSharp.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia.GtkSharp/Microsoft.Maui.Graphics.Skia.GtkSharp.csproj
@@ -11,9 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SkiaSharp" Version="2.88.0" />
-      <PackageReference Include="SkiaSharp.Views" Version="2.88.0" />
-      <PackageReference Include="SkiaSharp.Views.Gtk3" Version="2.88.0" />
+      <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+      <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
+      <PackageReference Include="SkiaSharp.Views.Gtk3" Version="$(SkiaSharpVersion)" />
 
     </ItemGroup>
 

--- a/src/Microsoft.Maui.Graphics.Skia.WPF/Microsoft.Maui.Graphics.Skia.WPF.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia.WPF/Microsoft.Maui.Graphics.Skia.WPF.csproj
@@ -13,9 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="SkiaSharp" Version="2.88.0" />
-      <PackageReference Include="SkiaSharp.Views" Version="2.88.0" />
-      <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.0" />
+      <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+      <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
+      <PackageReference Include="SkiaSharp.Views.WPF" Version="$(SkiaSharpVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-macos;net6.0-android;net6.0-maccatalyst;net6.0-tizen</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Skia</RootNamespace>
     <AssemblyName>Microsoft.Maui.Graphics.Skia</AssemblyName>
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.2-preview.5" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android')) or $(TargetFramework.Contains('-ios')) or $(TargetFramework.Contains('-macos')) or $(TargetFramework.Contains('-maccatalyst')) or $(TargetFramework.Contains('-tizen'))">
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.0" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.2-preview.5" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.0" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.2-preview.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.2-preview.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android')) or $(TargetFramework.Contains('-ios')) or $(TargetFramework.Contains('-macos')) or $(TargetFramework.Contains('-maccatalyst')) or $(TargetFramework.Contains('-tizen'))">
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.2-preview.5" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.2-preview.5" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia-net6.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android')) or $(TargetFramework.Contains('-ios')) or $(TargetFramework.Contains('-macos')) or $(TargetFramework.Contains('-maccatalyst')) or $(TargetFramework.Contains('-tizen'))">
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp.Views.WinUI" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
+++ b/src/Microsoft.Maui.Graphics.Skia/Microsoft.Maui.Graphics.Skia.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.0" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.0" />
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Maui.Graphics.Skia/PublicAPI/net-tizen/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Maui.Graphics.Skia/PublicAPI/net-tizen/PublicAPI.Shipped.txt
@@ -93,7 +93,7 @@ Microsoft.Maui.Graphics.Skia.TextLine.Width.get -> float
 Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView
 Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView.Drawable.get -> Microsoft.Maui.Graphics.IDrawable
 Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView.Drawable.set -> void
-Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView.SkiaGraphicsView(ElmSharp.EvasObject parent, Microsoft.Maui.Graphics.IDrawable drawable = null) -> void
+Microsoft.Maui.Graphics.Skia.Views.SkiaGraphicsView.SkiaGraphicsView(Microsoft.Maui.Graphics.IDrawable drawable = null) -> void
 override Microsoft.Maui.Graphics.Skia.SkiaBitmapExportContext.Canvas.get -> Microsoft.Maui.Graphics.ICanvas
 override Microsoft.Maui.Graphics.Skia.SkiaBitmapExportContext.Dispose() -> void
 override Microsoft.Maui.Graphics.Skia.SkiaBitmapExportContext.Image.get -> Microsoft.Maui.Graphics.IImage

--- a/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Tizen.nui.cs
+++ b/src/Microsoft.Maui.Graphics.Skia/Views/SkiaGraphicsView.Tizen.nui.cs
@@ -1,0 +1,45 @@
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Graphics.Skia;
+using SkiaSharp.Views.Tizen.NUI;
+using Tizen.NUI;
+using SKPaintSurfaceEventArgs = SkiaSharp.Views.Tizen.SKPaintSurfaceEventArgs;
+
+namespace Microsoft.Maui.Graphics.Skia.Views
+{
+	public class SkiaGraphicsView : SKCanvasView
+	{
+		private IDrawable _drawable;
+		private SkiaCanvas _canvas;
+		private ScalingCanvas _scalingCanvas;
+
+		public SkiaGraphicsView(IDrawable drawable = null) : base()
+		{
+			_canvas = new SkiaCanvas();
+			_scalingCanvas = new ScalingCanvas(_canvas);
+			Drawable = drawable;
+			PaintSurface += OnPaintSurface;
+			IgnorePixelScaling = true;
+		}
+
+		public IDrawable Drawable
+		{
+			get => _drawable;
+			set
+			{
+				_drawable = value;
+				Invalidate();
+			}
+		}
+
+		protected virtual void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+		{
+			if (_drawable == null) return;
+
+			var skiaCanvas = e.Surface.Canvas;
+			skiaCanvas.Clear();
+
+			_canvas.Canvas = skiaCanvas;
+			_drawable.Draw(_scalingCanvas, new RectF(0, 0, e.Info.Width , e.Info.Height));
+		}
+	}
+}

--- a/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
+++ b/src/Microsoft.Maui.Graphics/Microsoft.Maui.Graphics-net6.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-macos;net6.0-tizen6.5</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0-ios;net6.0-android;net6.0-maccatalyst;net6.0-macos;net6.0-tizen</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/targets/MultiTargeting.targets
+++ b/src/targets/MultiTargeting.targets
@@ -65,7 +65,13 @@
     <Compile Remove="**\Win32\*.cs"/>
     <None Include="**\Win32\*.cs"/>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) == true Or '$(TargetPlatformIdentifier)' == 'tizen'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) == true">
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
+    <Compile Remove="**\*.Tizen.nui.cs" />
+    <None Include="**\*.Tizen.nui.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.Contains('-tizen'))">
+    <Compile Remove="**\*.Tizen.cs"/>
+    <None Include="**\*.Tizen.cs"/>
   </ItemGroup>
 </Project>

--- a/src/targets/MultiTargeting.targets
+++ b/src/targets/MultiTargeting.targets
@@ -34,6 +34,8 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('tizen')) != true  And '$(TargetPlatformIdentifier)' != 'tizen'">
     <Compile Remove="**\*.Tizen.cs"/>
     <None Include="**\*.Tizen.cs"/>
+    <Compile Remove="**\*.Tizen.nui.cs"/>
+    <None Include="**\*.Tizen.nui.cs"/>
     <Compile Remove="**\Tizen\*.cs"/>
     <None Include="**\Tizen\*.cs"/>
     <Compile Remove="**\Tizen\**\*.cs"/>


### PR DESCRIPTION
This PR is to change the tizen backend implementation of SkiaGrpahicsView from EFL (legacy Tizen UI FW) to NUI (brand new Tizen .NET UI FW). Please refer to MAUI([#9620](https://github.com/dotnet/maui/pull/9620)) and SkiaSharp([#2225](https://github.com/mono/SkiaSharp/pull/2225)) fixes related to this together.

~> Keep this PR as a draft until a new version of SkiaSharp packages is released.~